### PR TITLE
Add alpha version of channel support for live listeners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 .project
+.idea
 .DS_Store
 npm-debug*
 test

--- a/examples/live-updates.js
+++ b/examples/live-updates.js
@@ -4,8 +4,11 @@ if (!process.argv[2]) {
 }
 
 var Pipedrive = require(__dirname + '/../index');
-var pipedrive = new Pipedrive.Client(process.argv[2]);
+var pipedrive = new Pipedrive.Client(process.argv[2], { strictMode: true });
 var _ = require('lodash');
+
+
+var start = Date.now();
 
 pipedrive.on('deal.added', function(event, data) {
 	console.log('Deal ' + event.meta.id + ' was added ('+data.current.title+', worth '+data.current.value+' '+data.current.currency+')');

--- a/examples/live-updates.js
+++ b/examples/live-updates.js
@@ -1,0 +1,18 @@
+if (!process.argv[2]) {
+	process.stderr.write('Please provide API token!' + "\n");
+	process.exit();
+}
+
+var Pipedrive = require(__dirname + '/../index');
+var pipedrive = new Pipedrive.Client(process.argv[2]);
+var _ = require('lodash');
+
+pipedrive.on('added.deal', function(event, data) {
+	console.log('Deal ' + event.meta.id + ' was added ('+data.current.title+', worth '+data.current.value+' '+data.current.currency+')');
+	pipedrive.removeAllListeners();
+	process.exit();
+});
+
+pipedrive.on('listening', function() {
+	pipedrive.Deals.add({ title: 'Live deal', value: 10000, currency: 'EUR' });
+});

--- a/examples/live-updates.js
+++ b/examples/live-updates.js
@@ -7,12 +7,12 @@ var Pipedrive = require(__dirname + '/../index');
 var pipedrive = new Pipedrive.Client(process.argv[2]);
 var _ = require('lodash');
 
-pipedrive.on('added.deal', function(event, data) {
+pipedrive.on('deal.added', function(event, data) {
 	console.log('Deal ' + event.meta.id + ' was added ('+data.current.title+', worth '+data.current.value+' '+data.current.currency+')');
 	pipedrive.removeAllListeners();
 	process.exit();
 });
 
-pipedrive.on('listening', function() {
+pipedrive.on('connect', function() {
 	pipedrive.Deals.add({ title: 'Live deal', value: 10000, currency: 'EUR' });
 });

--- a/lib/Pipedrive.js
+++ b/lib/Pipedrive.js
@@ -28,6 +28,7 @@ var _ = require('lodash'),
 	qs = require('qs'),
 	rest = require('./restler'),
 	inflection = require('./inflection'),
+	Listener = require('./listener'),
 	protocol = process.env.PIPEDRIVE_API_PROTOCOL || 'https',
 	host = process.env.PIPEDRIVE_API_HOST || 'api.pipedrive.com',
 	version = process.env.PIPEDRIVE_API_VERSION || 'v1',
@@ -163,6 +164,8 @@ exports.Client = function(apiToken, strictMode) {
 	var that = this;
 	strict = !!strictMode;
 
+	var listener = new Listener(apiToken);
+
 	_.each(apiObjects, function(item) {
 		that[item.substr(0,1).toUpperCase() + item.substr(1)] = new Collection(item, apiToken);
 	});
@@ -185,6 +188,10 @@ exports.Client = function(apiToken, strictMode) {
 
 		return returnVal;
 	};
+
+	this.on = listener.on;
+	this.removeListener = listener.removeListener;
+	this.removeAllListeners = listener.removeAllListeners;
 
 	return this;
 };

--- a/lib/Pipedrive.js
+++ b/lib/Pipedrive.js
@@ -28,7 +28,7 @@ var _ = require('lodash'),
 	qs = require('qs'),
 	rest = require('./restler'),
 	inflection = require('./inflection'),
-	Listener = require('./listener'),
+	Channel = require('./channel'),
 	protocol = process.env.PIPEDRIVE_API_PROTOCOL || 'https',
 	host = process.env.PIPEDRIVE_API_HOST || 'api.pipedrive.com',
 	version = process.env.PIPEDRIVE_API_VERSION || 'v1',
@@ -164,7 +164,7 @@ exports.Client = function(apiToken, strictMode) {
 	var that = this;
 	strict = !!strictMode;
 
-	var listener = new Listener(apiToken);
+	var listener = new Channel(apiToken);
 
 	_.each(apiObjects, function(item) {
 		that[item.substr(0,1).toUpperCase() + item.substr(1)] = new Collection(item, apiToken);

--- a/lib/Pipedrive.js
+++ b/lib/Pipedrive.js
@@ -157,13 +157,17 @@ exports.authenticate = function(auth, callback) {
 	}, false);
 };
 
-exports.Client = function(apiToken, strictMode) {
+exports.Client = function(apiToken, options) {
 	if (!apiToken) {
 		throw new Error('Could not instantiate Pipedrive API Client - apiToken not given.');
 	}
 
-	var that = this;
-	strict = !!strictMode;
+	if (!options) {
+		options = { strictMode: false };
+	}
+
+	var that = this,
+		strict = !!options.strictMode;
 
 	var listener = new Channel(apiToken);
 
@@ -190,9 +194,12 @@ exports.Client = function(apiToken, strictMode) {
 		return returnVal;
 	};
 
-	this.on = listener.on;
-	this.removeListener = listener.removeListener;
-	this.removeAllListeners = listener.removeAllListeners;
+	if (strict) {
+		// in strict mode, we'll expose the event hub integration methods
+		this.on = listener.on;
+		this.removeListener = listener.removeListener;
+		this.removeAllListeners = listener.removeAllListeners;
+	}
 
 	return this;
 };

--- a/lib/channel.js
+++ b/lib/channel.js
@@ -110,8 +110,6 @@ function Channel(apiToken) {
 	};
 
 	this.restartClient = function() {
-		console.log('automatic client restart');
-
 		client.onopen = null;
 		client.onclose = null;
 		client.onmessage = null;

--- a/lib/channel.js
+++ b/lib/channel.js
@@ -4,12 +4,13 @@ var SockJS = require('sockjs-client-node'),
 	fetch = require('fetch'),
 	_ = require('lodash');
 
-module.exports = Listener;
+module.exports = Channel;
 
-function Listener(apiToken) {
+function Channel(apiToken) {
 
 	var handlers = {},
 		self = this,
+		client = null,
 		clientStarted = false;
 	
 	this.startClient = function() {
@@ -18,7 +19,7 @@ function Listener(apiToken) {
 		}
 		clientStarted = true;
 
-		var client = new SockJS((process.env.PIPEDRIVE_API_PROTOCOL || 'https')+'://'+(process.env.PIPEDRIVE_CHANNEL_HOST || 'channel.pipedrive.com')+'/sockjs');
+		client = new SockJS((process.env.PIPEDRIVE_API_PROTOCOL || 'https')+'://'+(process.env.PIPEDRIVE_CHANNEL_HOST || 'channel.pipedrive.com')+'/sockjs');
 
 		client.onopen = function () {
 			var options = {
@@ -53,7 +54,9 @@ function Listener(apiToken) {
 		};
 		client.onmessage = function (msg) {
 			if (msg && msg.type === 'message') {
-				var data = {};
+				var data = {},
+					eventPatterns = [];
+
 				try {
 					data = JSON.parse(msg.data);
 				}
@@ -62,34 +65,26 @@ function Listener(apiToken) {
 				}
 
 				if (data && data.meta && data.meta.v === 1) {
-					if (handlers[data.meta.action + '.' + data.meta.object]) {
-						_.each(handlers[data.meta.action + '.' + data.meta.object], function(handler) {
-							handler(data, data.data);
-						});
-					}
 
-					if (handlers['*.' + data.meta.object]) {
-						_.each(handlers['*.' + data.meta.object], function(handler) {
-							handler(data, data.data);
-						});
-					}
+					eventPatterns = [
+						data.meta.object + '.' + data.meta.action,
+						'*.' + data.meta.action,
+						data.meta.object + '.*',
+						'*.*'
+					];
 
-					if (handlers[data.meta.action + '.*']) {
-						_.each(handlers[data.meta.action + '.*'], function(handler) {
-							handler(data, data.data);
-						});
-					}
-
-					if (handlers['*.*']) {
-						_.each(handlers['*.*'], function(handler) {
-							handler(data, data.data);
-						});
-					}
+					_.each(eventPatterns, function(pattern) {
+						if (handlers[pattern]) {
+							_.each(handlers[pattern], function(handler) {
+								handler(data, data.data);
+							});
+						}
+					});
 				}
 
 				if (data.rabbitStateChange === 'open') {
-					if (handlers['listening']) {
-						_.each(handlers['listening'], function(handler) {
+					if (handlers['connect']) {
+						_.each(handlers['connect'], function(handler) {
 							handler();
 						});
 					}
@@ -97,7 +92,12 @@ function Listener(apiToken) {
 			}
 		};
 		client.onclose = function (e) {
-			handlers = {};
+			clientStarted = false;
+			if (handlers['close']) {
+				_.each(handlers['close'], function(handler) {
+					handler(e);
+				});
+			}
 		};
 	}
 
@@ -114,10 +114,16 @@ function Listener(apiToken) {
 		if (index > -1) {
 			handlers[method].splice(index, 1);
 		}
+		if (!handlers.length) {
+			this.removeAllListeners();
+		}
 	}
 
 	this.removeAllListeners = function() {
 		handlers = {};
+		if (client && client.close) {
+			client.close();
+		}
 	}
 
 }

--- a/lib/channel.js
+++ b/lib/channel.js
@@ -11,13 +11,15 @@ function Channel(apiToken) {
 	var handlers = {},
 		self = this,
 		client = null,
-		clientStarted = false;
+		clientStarted = false,
+		clientClosed = false;
 	
 	this.startClient = function() {
 		if (clientStarted) {
 			return;
 		}
 		clientStarted = true;
+		clientClosed = false;
 
 		client = new SockJS((process.env.PIPEDRIVE_API_PROTOCOL || 'https')+'://'+(process.env.PIPEDRIVE_CHANNEL_HOST || 'channel.pipedrive.com')+'/sockjs');
 
@@ -26,7 +28,7 @@ function Channel(apiToken) {
 				rejectUnauthorized: false
 			};
 			fetch.fetchUrl((process.env.PIPEDRIVE_API_PROTOCOL || 'https')+'://'+(process.env.PIPEDRIVE_API_HOST || 'api.pipedrive.com')+'/v1/authorizations/nonce?api_token=' + encodeURIComponent(apiToken), options, function(error, meta, body) {
-				var data = {}
+				var data = {};
 				try {
 					data = JSON.parse(body);
 					if (data.data) {
@@ -92,6 +94,12 @@ function Channel(apiToken) {
 			}
 		};
 		client.onclose = function (e) {
+			if (!clientClosed) {
+				// not closed by user - we have some connection error.
+				self.restartClient();
+				return;
+			}
+
 			clientStarted = false;
 			if (handlers['close']) {
 				_.each(handlers['close'], function(handler) {
@@ -99,7 +107,20 @@ function Channel(apiToken) {
 				});
 			}
 		};
-	}
+	};
+
+	this.restartClient = function() {
+		console.log('automatic client restart');
+
+		client.onopen = null;
+		client.onclose = null;
+		client.onmessage = null;
+		client = null;
+
+		clientStarted = false;
+
+		setTimeout(self.startClient, (1+Math.random()*4)*1000);
+	};
 
 	this.on = function(method, handler) {
 		if (!clientStarted) {
@@ -114,13 +135,15 @@ function Channel(apiToken) {
 		if (index > -1) {
 			handlers[method].splice(index, 1);
 		}
-		if (!handlers.length) {
+		if (!_.keys(handlers).length) {
 			this.removeAllListeners();
 		}
-	}
+	};
 
 	this.removeAllListeners = function() {
 		handlers = {};
+		clientClosed = true;
+
 		if (client && client.close) {
 			client.close();
 		}

--- a/lib/listener.js
+++ b/lib/listener.js
@@ -79,6 +79,12 @@ function Listener(apiToken) {
 							handler(data, data.data);
 						});
 					}
+
+					if (handlers['*.*']) {
+						_.each(handlers['*.*'], function(handler) {
+							handler(data, data.data);
+						});
+					}
 				}
 
 				if (data.rabbitStateChange === 'open') {

--- a/lib/listener.js
+++ b/lib/listener.js
@@ -1,0 +1,117 @@
+'use strict';
+
+var SockJS = require('sockjs-client-node'),
+	fetch = require('fetch'),
+	_ = require('lodash');
+
+module.exports = Listener;
+
+function Listener(apiToken) {
+
+	var handlers = {},
+		self = this,
+		clientStarted = false;
+	
+	this.startClient = function() {
+		if (clientStarted) {
+			return;
+		}
+		clientStarted = true;
+
+		var client = new SockJS("https://channel.pipedrive.com/sockjs");
+
+		client.onopen = function () {
+			var options = {
+				rejectUnauthorized: false
+			};
+			fetch.fetchUrl('https://api.pipedrive.com/v1/authorizations/nonce?api_token=' + encodeURIComponent(apiToken), options, function(error, meta, body) {
+				var data = {}
+				try {
+					data = JSON.parse(body);
+					if (data.data) {
+						data = data.data;
+					}
+				}
+				catch (e) {
+					throw new Error('Could not parse API response');
+				}
+
+				if (data && data.nonce) {
+					client.send(JSON.stringify({
+							company_id: data.company_id,
+							user_id: data.user_id,
+							user_name: 'client-nodejs-user',
+							host: 'app.pipedrive.com',
+							timestamp: Math.round(new Date().getTime() / 1000),
+							nonce: data.nonce
+					}));
+				}
+				else {
+					throw new Error('Authorization failed');
+				}
+			});
+		};
+		client.onmessage = function (msg) {
+			if (msg && msg.type === 'message') {
+				var data = {};
+				try {
+					data = JSON.parse(msg.data);
+				}
+				catch (e) {
+					throw new Error('Malformed JSON received from socket');
+				}
+
+				if (data && data.meta && data.meta.v === 1) {
+					if (handlers[data.meta.action + '.' + data.meta.object]) {
+						_.each(handlers[data.meta.action + '.' + data.meta.object], function(handler) {
+							handler(data, data.data);
+						});
+					}
+
+					if (handlers['*.' + data.meta.object]) {
+						_.each(handlers['*.' + data.meta.object], function(handler) {
+							handler(data, data.data);
+						});
+					}
+
+					if (handlers[data.meta.action + '.*']) {
+						_.each(handlers[data.meta.action + '.*'], function(handler) {
+							handler(data, data.data);
+						});
+					}
+				}
+
+				if (data.rabbitStateChange === 'open') {
+					if (handlers['listening']) {
+						_.each(handlers['listening'], function(handler) {
+							handler();
+						});
+					}
+				}
+			}
+		};
+		client.onclose = function (e) {
+			handlers = {};
+		};
+	}
+
+	this.on = function(method, handler) {
+		if (!clientStarted) {
+			self.startClient();
+		}
+		handlers[method] = handlers[method] || [];
+		handlers[method].push(handler);
+	};
+
+	this.removeListener = function(method, handler) {
+		var index = handlers[method].indexOf(handler);
+		if (index > -1) {
+			handlers[method].splice(index, 1);
+		}
+	}
+
+	this.removeAllListeners = function() {
+		handlers = {};
+	}
+
+}

--- a/lib/listener.js
+++ b/lib/listener.js
@@ -18,13 +18,13 @@ function Listener(apiToken) {
 		}
 		clientStarted = true;
 
-		var client = new SockJS("https://channel.pipedrive.com/sockjs");
+		var client = new SockJS((process.env.PIPEDRIVE_API_PROTOCOL || 'https')+'://'+(process.env.PIPEDRIVE_CHANNEL_HOST || 'channel.pipedrive.com')+'/sockjs');
 
 		client.onopen = function () {
 			var options = {
 				rejectUnauthorized: false
 			};
-			fetch.fetchUrl('https://api.pipedrive.com/v1/authorizations/nonce?api_token=' + encodeURIComponent(apiToken), options, function(error, meta, body) {
+			fetch.fetchUrl((process.env.PIPEDRIVE_API_PROTOCOL || 'https')+'://'+(process.env.PIPEDRIVE_API_HOST || 'api.pipedrive.com')+'/v1/authorizations/nonce?api_token=' + encodeURIComponent(apiToken), options, function(error, meta, body) {
 				var data = {}
 				try {
 					data = JSON.parse(body);

--- a/package.json
+++ b/package.json
@@ -1,22 +1,32 @@
 {
-	"name": "pipedrive",
-	"version": "1.7.2",
-	"description": "Pipedrive REST client for NodeJS",
-	"keywords":["pipedrive","CRM","sales","contacts","customers","deals","pipeline","sales pipeline"],
-	"homepage": "https://github.com/pipedrive/client-nodejs",
-	"main":"./lib/Pipedrive",
-	"engines": {
-		"node": ">= 0.8.x"
-	},
-	"repository": {
-		"type": "git",
-		"url": "http://github.com/pipedrive/client-nodejs.git"
-	},
-	"dependencies": {
-		"qs": "~2.1.0",
-		"lodash": "~2.4.1",
-		"fetch": "~0.3.6",
-		"mime": "~1.2.11",
-		"async": "~0.9.0"
-	}
+  "name": "pipedrive",
+  "version": "2.0.0",
+  "description": "Pipedrive REST client for NodeJS",
+  "keywords": [
+    "pipedrive",
+    "CRM",
+    "sales",
+    "contacts",
+    "customers",
+    "deals",
+    "pipeline",
+    "sales pipeline"
+  ],
+  "homepage": "https://github.com/pipedrive/client-nodejs",
+  "main": "./lib/Pipedrive",
+  "engines": {
+    "node": ">= 0.8.x"
+  },
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/pipedrive/client-nodejs.git"
+  },
+  "dependencies": {
+    "async": "~0.9.0",
+    "fetch": "~0.3.6",
+    "lodash": "~2.4.1",
+    "mime": "~1.2.11",
+    "qs": "~2.1.0",
+    "sockjs-client-node": "^0.2.1"
+  }
 }


### PR DESCRIPTION
 * Client now exposes .on() method which can be used to set up event listeners for actions taken on the account that the authenticated user can access as they happen in near-real-time. This is highly experimental at this stage, and thus not publicly documented in readme.
 * Client init takes second argument as object of options now. 