### PR TITLE
Swap sockjs-client-node with sockjs-client

### DIFF
--- a/lib/channel.js
+++ b/lib/channel.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var SockJS = require('sockjs-client-node'),
+var SockJS = require('sockjs-client'),
 	fetch = require('fetch'),
 	_ = require('lodash');
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "lodash": "~2.4.1",
     "mime": "~1.2.11",
     "qs": "~2.1.0",
-    "sockjs-client-node": "^0.2.1"
+    "sockjs-client": "^1.0.3"
   }
 }


### PR DESCRIPTION
Swapping to sockjs-client allows package to work with recent versions of Node (4.x), though I'm unsure if it has any impact on older versions (untested). Anyway, sockjs-client-node is deprecated.