### PR TITLE
Prevent getAll looping indefinitely when error occurs

### DIFF
--- a/lib/Pipedrive.js
+++ b/lib/Pipedrive.js
@@ -191,7 +191,7 @@ THE SOFTWARE.
 					limit: perPage
 				}, function(err, models) {
 					if (err) {
-						callback(err);
+						return callback(err);
 					} else {
 						collection = collection.concat(models);
 						if (models.length < perPage) {


### PR DESCRIPTION
Return when calling the callback when an error occurs.  Prevent
retrieving of next page (which will fail again).

A simple scenario would be an Invalid API token.