### PR TITLE
Add params option to getAll

### DIFF
--- a/lib/Pipedrive.js
+++ b/lib/Pipedrive.js
@@ -175,7 +175,11 @@ THE SOFTWARE.
 				return baseUri + '/' + path + (_.keys(queryObj).length > 0 ? '?' + qs.stringify(queryObj) : '');
 			};
 
-		this.getAll = function(resource, callback) {
+		this.getAll = function(resource, params, callback) {
+
+			callback = (_.isFunction(params) && _.isUndefined(callback) ? params : callback);
+			params = (_.isFunction(params) && _.isUndefined(callback) ? {} : params);
+
 			var collection = [],
 				self = this,
 				page = 0,
@@ -186,10 +190,10 @@ THE SOFTWARE.
 				if (!self[resource]) {
 					throw new Error(resource+' is not supported object type for getAll()');
 				}
-				self[resource].getAll({
+				self[resource].getAll(_.extend({}, params, {
 					start: start,
 					limit: perPage
-				}, function(err, models) {
+				}), function(err, models) {
 					if (err) {
 						callback(err);
 					} else {


### PR DESCRIPTION
Allow user to pass params to getAll
- Useful for requests that takes optional params (Activities, Deals)