### PR TITLE
Ind-13 - deal.merge & duplicate does not return full deal object

### DIFF
--- a/lib/CollectionItem.js
+++ b/lib/CollectionItem.js
@@ -35,12 +35,18 @@
 			return (!_.isUndefined(data[key]) ? data[key] : undefinedProperty);
 		};
 
-		this.merge = function(withId, callback) {
-			return restHandlers.mergeItem(data.id, withId, kind, callback);
+		this.merge = function (withId, callback) {
+			return restHandlers.mergeItem(data.id, withId, kind, function (error, data, additionalData, req, res) {
+				var collectionItems = wrapCollectionItems([data], kind, options);
+				callback(error, collectionItems[0], additionalData, req, res);
+			});
 		};
 
-		this.duplicate = function(callback) {
-			return restHandlers.duplicateItem(data.id, kind, callback);
+		this.duplicate = function (callback) {
+			return restHandlers.duplicateItem(data.id, kind, function (error, data, additionalData, req, res) {
+				var collectionItems = wrapCollectionItems([data], kind, options);
+				callback(error, collectionItems[0], additionalData, req, res);
+			});
 		};
 
 		this.toObject = function() {

--- a/lib/CollectionItem.js
+++ b/lib/CollectionItem.js
@@ -22,7 +22,11 @@
 		var changedData = {};
 
 		this.save = function(saveCallback) {
-			restHandlers.editItem(data.id, kind, changedData, saveCallback);
+			restHandlers.editItem(data.id, kind, changedData, function (error, data, additionalData, req, res) {
+				var collectionItems = wrapCollectionItems([data], kind, options);
+				saveCallback(error, collectionItems[0], additionalData, req, res);
+			});
+
 			changedData = {};
 			return currentItem;
 		};


### PR DESCRIPTION
Client calls like https://github.com/pipedrive/client-nodejs#objectmergewithid-fn-callback
should return the full object with all it's methods present (like duplicate, merge)
right now they only return an object with the raw attributes

p.s. added save() to return object with methods too