### PR TITLE
Add support for related objects fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Fetches the possible API tokens for the given user against email and password, p
 Add an object. Returns ```error, data``` to the callback where data contains the ```id``` property of the newly created item.
 
 ### pipedrive.{Object}.get (id, [fn callback])
-Get specific object. Returns ```error, object```
+Get specific object. Returns ```error, object, additionalData, rawRequest, rawResponse, relatedObjects```
 
 ### pipedrive.{Object}.update (id, data, [fn callback])
 Update an object. Returns ```error``` in case of an error to the callback.

--- a/examples/list-deals.js
+++ b/examples/list-deals.js
@@ -27,7 +27,7 @@ pipedrive.Filters.getAll({ type: 'deals' }, function(filtersListErr, filtersList
 	if (filtersList.length > 0) {
 		console.log('Fetching deals that match filter "' + filtersList[0].get('name') + '"...');
 
-		pipedrive.Deals.getAll({ filter_id: filtersList[0].get('id'), start: 0, limit: 5 }, function(dealsListErr, dealsList) {
+		pipedrive.Deals.getAll({ filter_id: filtersList[0].get('id'), start: 0, limit: 5 }, function(dealsListErr, dealsList, additionalData, rawReq, rawRes, relatedObjects) {
 			if (dealsListErr) console.log(dealsListErr);
 			_.each(dealsList, function(deal) {
 				deal.getActivities(function(err, activities) {

--- a/lib/Collection.js
+++ b/lib/Collection.js
@@ -15,9 +15,9 @@
 			restHandlers = new RestHandlers(options);
 
 		this.getAll = function(params, getAllCallback) {
-			return restHandlers.listItems(kind, params, function(error, data, additionalData, req, res) {
+			return restHandlers.listItems(kind, params, function(error, data, additionalData, req, res, relatedObjects) {
 				var collectionItems = wrapCollectionItems(data, kind, options);
-				(_.isFunction(params) ? params : getAllCallback)(error, collectionItems, additionalData, req, res);
+				(_.isFunction(params) ? params : getAllCallback)(error, collectionItems, additionalData, req, res, relatedObjects);
 			});
 		};
 
@@ -26,9 +26,9 @@
 				throw new Error('Cannot get ' + inflection.singularize(kind) + ' - ID must be given.');
 			}
 
-			return restHandlers.getItem(kind, id, function(error, data, additionalData, req, res) {
+			return restHandlers.getItem(kind, id, function(error, data, additionalData, req, res, relatedObjects) {
 				if (data !== null && !_.isUndefined(data) && data.id) {
-					getCallback(null, new CollectionItem(kind, data, data.id, options), additionalData, req, res);
+					getCallback(null, new CollectionItem(kind, data, data.id, options), additionalData, req, res, relatedObjects);
 				}
 				else {
 					getCallback(error, data, additionalData, req, res);
@@ -69,17 +69,17 @@
 					callback(new Error('The term parameter must be supplied for finding ' + kind + '.'));
 					return false;
 				}
-				return restHandlers.findItems(kind, params, function(error, data, additionalData, req, res) {
+				return restHandlers.findItems(kind, params, function(error, data, additionalData, req, res, relatedObjects) {
 					var collectionItems = wrapCollectionItems(data, kind, options);
-					callback(error, collectionItems, additionalData, req, res);
+					callback(error, collectionItems, additionalData, req, res, relatedObjects);
 				});
 			};
 		}
 
 		if (_.indexOf(blueprint.timelineableObjects, kind) !== -1) {
 			this.getTimeline = function(params, callback) {
-				return restHandlers.timelineItems(kind, params, function(error, data, additionalData, req, res) {
-					(_.isFunction(params) ? params : callback)(error, data, additionalData, req, res);
+				return restHandlers.timelineItems(kind, params, function(error, data, additionalData, req, res, relatedObjects) {
+					(_.isFunction(params) ? params : callback)(error, data, additionalData, req, res, relatedObjects);
 				});
 			};
 		}
@@ -95,9 +95,9 @@
 					return false;
 				}
 				params.exact_match = params.exact_match ? '1' : '0';
-				return restHandlers.searchFields(kind, params, function(error, data, additionalData, req, res) {
+				return restHandlers.searchFields(kind, params, function(error, data, additionalData, req, res, relatedObjects) {
 					var collectionItems = wrapCollectionItems(data, inflection.pluralize(params.field_type.replace('Field','').toLowerCase()), options);
-					callback(error, collectionItems, additionalData, req, res);
+					callback(error, collectionItems, additionalData, req, res, relatedObjects);
 				});
 			};
 		}

--- a/lib/restHandlers.js
+++ b/lib/restHandlers.js
@@ -27,6 +27,7 @@
 		var statusCodeGroup = parseInt((rawResponse.statusCode || 0).toString().substr(0, 1), 10),
 			responseError = null,
 			responseData = {},
+			responseRelatedObjects = {},
 			responseAdditionalData = {};
 
 		if (_.isString(responseBody)) {
@@ -41,6 +42,7 @@
 		if (!responseError && responseBody.success === true) {
 			responseError = null;
 			responseData = responseBody.data;
+			responseRelatedObjects = responseBody.related_objects;
 			responseAdditionalData = responseBody.additional_data;
 		}
 		else if (statusCodeGroup === 4 || statusCodeGroup === 5) {
@@ -68,12 +70,13 @@
 
 			responseData = null;
 			responseAdditionalData = null;
+			responseRelatedObjects = null;
 		}
 		else if (responseBody.error) {
 			responseError = new Error(responseBody.error);
 		}
 
-		callback(responseError, responseData, responseAdditionalData, rawRequest, rawResponse);
+		callback(responseError, responseData, responseAdditionalData, rawRequest, rawResponse, responseRelatedObjects);
 	};
 
 	// GET /items

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "sockjs-client": "^1.0.3"
   },
   "devDependencies": {
-    "mocha": "^3.2.0",
-    "should": "^11.1.2"
+    "chai": "^4.1.2",
+    "mocha": "^3.2.0"
   }
 }

--- a/test/integration/client.js
+++ b/test/integration/client.js
@@ -1,0 +1,112 @@
+var Pipedrive = require('./../..');
+var assert = require('chai').assert;
+
+var API_TOKEN = process.env.API_TOKEN;
+if (!API_TOKEN) {
+	process.stderr.write('Please provide API_TOKEN in env variables for tests to run' + "\n");
+	process.exit();
+}
+
+describe('client', function () {
+
+	var client, strictClient;
+
+	beforeEach(function () {
+		client = new Pipedrive.Client(API_TOKEN);
+		strictClient = new Pipedrive.Client(API_TOKEN, {strictMode: true});
+	});
+
+	describe('.getAll()', function () {
+		it('should list filters and deals', function (done) {
+			client.Filters.getAll({type: 'deals'}, function (filtersListErr, filtersList) {
+
+				assert.isTrue(filtersList.length > 0);
+				assert.equal(filtersList[0].get('name'), 'All open deals');
+
+				client.Deals.getAll(
+					{filter_id: filtersList[0].get('id'), start: 0, limit: 5},
+					function (dealsListErr, dealsList, additionalData, rawReq, rawRes, relatedObjects) {
+						assert.isTrue(dealsList.length > 0);
+
+						assert.isDefined(relatedObjects.user);
+						assert.isDefined(relatedObjects.organization);
+
+						done();
+					});
+			});
+		});
+	});
+
+	describe('.add() & .getItem()', function () {
+		it('should create and get deal', function (done) {
+
+			var payloadDeal = {
+				title: 'Client-nodejs - .add() test',
+				value: Math.ceil(Math.random() * 1000),
+				currency: 'EUR'
+			};
+
+			//create
+			client.Deals.add(payloadDeal, function (dealAddError, createdDeal) {
+				assert.isDefined(createdDeal.id);
+
+				//get
+				client.Deals.get(createdDeal.id, function (dealsListErr, fetchedDeal, additionalData, rawReq, rawRes, relatedObjects) {
+					assert.equal(fetchedDeal.value, payloadDeal.value);
+					assert.equal(fetchedDeal.title, payloadDeal.title);
+
+					assert.isDefined(relatedObjects.user);
+
+					//cleanup
+					client.Deals.remove(createdDeal.id, function () {
+						done();
+					});
+				});
+			});
+		});
+	});
+
+	describe('.on()', function () {
+		it('should allow event binding to connect and deal adding', function (done) {
+			this.timeout(10000);
+
+			var deal = {title: 'Client-nodejs - .on() test', value: 10000, currency: 'EUR'};
+
+			strictClient.on('connect', function () {
+				strictClient.Deals.add(deal, function (error, result) {
+					deal.id = result.id;
+				});
+			});
+
+			strictClient.on('deal.added', function (event, data) {
+				assert.equal(data.current.title, deal.title);
+				assert.equal(data.current.value, deal.value);
+				assert.equal(data.current.currency, deal.currency);
+
+				strictClient.removeAllListeners();
+
+				//cleanup
+				strictClient.Deals.remove(deal.id, function () {
+					done();
+				});
+			});
+		});
+	});
+
+	describe('.find()', function () {
+		it('should find first person by name', function (done) {
+			client.Persons.getAll(function (err, listedPersons) {
+				assert.isTrue(listedPersons.length > 0);
+
+				client.Persons.find({term: listedPersons[0].name}, function (error, foundPersons, additionalData, req, res, relatedObjects) {
+					assert.equal(foundPersons.length, 1);
+					assert.equal(foundPersons[0].id, listedPersons[0].id);
+
+					//search does not include related objects yet
+					assert.isUndefined(relatedObjects);
+					done();
+				});
+			});
+		})
+	})
+});

--- a/test/unit/client.js
+++ b/test/unit/client.js
@@ -1,4 +1,4 @@
-var should = require('should/as-function'),
+var assert = require('chai').assert,
 	Pipedrive = require('./../..'),
 	blueprint = require('./../../lib/blueprint');
 
@@ -10,28 +10,28 @@ describe('client module', function () {
 	});
 
 	it('should expose main API objects', function () {
-		should(client.Activities).be.an.Object();
-		should(client.Deals).be.an.Object();
+		assert.isObject(client.Activities);
+		assert.isObject(client.Deals);
 
 		// iterate through all
 		blueprint.apiObjects.forEach(function (obj) {
-			should(client[obj.substr(0, 1).toUpperCase() + obj.substr(1)]).be.an.Object();
+			assert.isObject(client[obj.substr(0, 1).toUpperCase() + obj.substr(1)]);
 		});
 	});
 
 	describe('client.on()', function () {
 		it('should be defined in strict mode', function () {
-			should(strictClient.on).be.a.Function();
+			assert.isFunction(strictClient.on);
 		});
 
 		it('should not be defined in regular mode', function () {
-			should(client.on).be.a.Undefined();
+			assert.isUndefined(client.on);
 		});
 	});
 
 	it('client.getAll() should throw error if non-existant resource is requested', function (done) {
 		client.getAll('bananas', function (error) {
-			should(error.message).equal('bananas is not supported object type for getAll()');
+			assert.equal(error.message, 'bananas is not supported object type for getAll()');
 			return done();
 		});
 	});

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -1,4 +1,4 @@
-var should = require('should');
+var assert = require('chai').assert;
 
 describe('main module', function() {
 
@@ -9,8 +9,8 @@ describe('main module', function() {
 	it('should expose top-level functionality', function() {
 		var Pipedrive = require('./../..');
 
-		should(Pipedrive.Client).be.a.Function();
-		should(Pipedrive.authenticate).be.a.Function();
+		assert.isFunction(Pipedrive.Client);
+		assert.isFunction(Pipedrive.authenticate);
 	});
 
 });

--- a/test/unit/restHandlers.js
+++ b/test/unit/restHandlers.js
@@ -1,4 +1,4 @@
-var should = require('should');
+var assert = require('chai').assert;
 
 describe('lib/restHandlers', function () {
 
@@ -23,14 +23,14 @@ describe('lib/restHandlers', function () {
 			var called = false;
 			var callback = function (responseError, responseData) {
 				called = true;
-				should(responseData.length).be.equal(1);
-				should(responseData[0].id).be.equal(1);
+				assert.equal(responseData.length, 1);
+				assert.equal(responseData[0].id, 1);
 			};
 
 			restHandlers.genericResponse(
 				'GET', {}, responseBody, callback, defaultRequest, defaultResponse
 			);
-			should(called).be.equal(true);
+			assert.isTrue(called);
 		});
 
 		it('should pass error in callback on response containing error', function () {
@@ -39,13 +39,13 @@ describe('lib/restHandlers', function () {
 			var called = false;
 			var callback = function (responseError) {
 				called = true;
-				should(responseError.message).be.equal('Backend error');
+				assert.equal(responseError.message, 'Backend error');
 			};
 
 			restHandlers.genericResponse(
 				'GET', {}, responseBody, callback, defaultRequest, defaultResponse
 			);
-			should(called).be.equal(true);
+			assert.isTrue(called);
 		});
 
 		describe('error cases', function () {
@@ -54,7 +54,7 @@ describe('lib/restHandlers', function () {
 					'GET', {}, {}, null, defaultRequest
 				);
 
-				should(result).be.equal(undefined);
+				assert.isUndefined(result);
 			});
 
 			it('should throw basic error if response body is not json (plain text)', function () {
@@ -63,13 +63,13 @@ describe('lib/restHandlers', function () {
 				var called = false;
 				var callback = function (responseError) {
 					called = true;
-					should(responseError.message).be.equal('Malformed Pipedrive API response');
+					assert.equal(responseError.message, 'Malformed Pipedrive API response');
 				};
 
 				restHandlers.genericResponse(
 					'GET', {}, responseBody, callback, defaultRequest, defaultResponse
 				);
-				should(called).be.equal(true);
+				assert.isTrue(called);
 			});
 
 
@@ -80,7 +80,7 @@ describe('lib/restHandlers', function () {
 					var called = false;
 					var callback = function (responseError) {
 						called = true;
-						should(responseError.message).be.equal('Pipedrive API error:Backend error');
+						assert.equal(responseError.message, 'Pipedrive API error:Backend error');
 					};
 
 					restHandlers.genericResponse(
@@ -88,7 +88,7 @@ describe('lib/restHandlers', function () {
 							statusCode: 500
 						}
 					);
-					should(called).be.equal(true);
+					assert.isTrue(called);
 				});
 
 				it('should throw "Malformed" error, if response is not json', function () {
@@ -97,7 +97,7 @@ describe('lib/restHandlers', function () {
 					var called = false;
 					var callback = function (responseError) {
 						called = true;
-						should(responseError.message).be.equal('Malformed Pipedrive API response');
+						assert.equal(responseError.message, 'Malformed Pipedrive API response');
 					};
 
 					restHandlers.genericResponse(
@@ -106,7 +106,7 @@ describe('lib/restHandlers', function () {
 							rawEncoded: responseBody
 						}
 					);
-					should(called).be.equal(true);
+					assert.isTrue(called);
 				});
 
 				describe('raw response handling', function () {
@@ -117,7 +117,7 @@ describe('lib/restHandlers', function () {
 						var called = false;
 						var callback = function (responseError) {
 							called = true;
-							should(responseError.message).be.equal('Custom error');
+							assert.equal(responseError.message, 'Custom error');
 						};
 
 						restHandlers.genericResponse(
@@ -128,7 +128,7 @@ describe('lib/restHandlers', function () {
 								}
 							}
 						);
-						should(called).be.equal(true);
+						assert.isTrue(called);
 					});
 
 					it('should throw custom error object, if body.error is missing, but rawEncoded.error is passed from rest.js', function () {
@@ -137,7 +137,7 @@ describe('lib/restHandlers', function () {
 						var called = false;
 						var callback = function (responseError) {
 							called = true;
-							should(responseError.message).be.equal('Pipedrive API error:Custom backend error');
+							assert.equal(responseError.message, 'Pipedrive API error:Custom backend error');
 						};
 
 						restHandlers.genericResponse(
@@ -146,7 +146,7 @@ describe('lib/restHandlers', function () {
 								rawEncoded: '{"error":"Custom backend error"}'
 							}
 						);
-						should(called).be.equal(true);
+						assert.isTrue(called);
 					});
 				});
 			});


### PR DESCRIPTION
 * **Adds support for related objects fetching.** In related objects (passed down as the sixth argument when fetching objects, or lists of objects) , Pipedrive API passes down things like pictures of persons, relevant user profile data etc that would be needed to properly render the underlying objects to a human being.
 * Since related objects do not represent complete objects, they are not wrapped as collectionItems and thus have to be used as data stubs only. This is intentional by design.