### PR TITLE
Fix for item.save() never calling its callback function

### DIFF
--- a/lib/CollectionItem.js
+++ b/lib/CollectionItem.js
@@ -23,7 +23,7 @@
 
 		this.save = function(saveCallback) {
 			restHandlers.editItem(data.id, kind, changedData, function (error, data, additionalData, req, res) {
-				var collectionItems = wrapCollectionItems([data], kind, options);
+				var collectionItems = wrapCollectionItems(data ? [data] : data, kind, options);
 				saveCallback(error, collectionItems[0], additionalData, req, res);
 			});
 
@@ -41,14 +41,14 @@
 
 		this.merge = function (withId, callback) {
 			return restHandlers.mergeItem(data.id, withId, kind, function (error, data, additionalData, req, res) {
-				var collectionItems = wrapCollectionItems([data], kind, options);
+				var collectionItems = wrapCollectionItems(data ? [data] : data, kind, options);
 				callback(error, collectionItems[0], additionalData, req, res);
 			});
 		};
 
 		this.duplicate = function (callback) {
 			return restHandlers.duplicateItem(data.id, kind, function (error, data, additionalData, req, res) {
-				var collectionItems = wrapCollectionItems([data], kind, options);
+				var collectionItems = wrapCollectionItems(data ? [data] : data, kind, options);
 				callback(error, collectionItems[0], additionalData, req, res);
 			});
 		};

--- a/test/unit/CollectionItem.js
+++ b/test/unit/CollectionItem.js
@@ -10,7 +10,7 @@ describe('CollectionItem', function () {
 	var restHandlersPath = path.normalize(__dirname + '/../../lib/restHandlers');
 
 	var restHandlerMock = {
-		editItem: sinon.spy(),
+		editItem: sinon.stub(),
 		listItems: sinon.spy()
 	};
 
@@ -23,6 +23,7 @@ describe('CollectionItem', function () {
 		var CollectionItem = proxyquire('./../../lib/CollectionItem', stubs);
 
 		item = new CollectionItem('deals', {
+			id: 1,
 			title: 'Deal title'
 		}, 1);
 
@@ -62,6 +63,50 @@ describe('CollectionItem', function () {
 
 			sinon.assert.calledOnce(restHandlerMock.editItem);
 			sinon.assert.calledWith(restHandlerMock.editItem, 2, 'deals/1/products', {id: 2});
+		});
+	});
+
+	describe('item.save()', function() {
+		it('should call restHandler.editItem()', function () {
+			// In the normal case, we can set a field value and call save().  Internally, the restHandler.editItem()
+			// method will be called with our update.
+			item.set('title', 'Other deal title');
+			item.save();
+
+			sinon.assert.calledWith(restHandlerMock.editItem, 1, 'deals', {title: 'Other deal title'});
+		});
+
+		it('should handle error with null data from REST call', function () {
+			// Set a field to a field ID that doesn't exist (maybe the custom field key is bad).
+			item.set('badFieldId', 'Ignored value');
+
+			// When we save the item in this state, the real RestHandler.editItem() is given bad input, so it receives
+			// back an error response, such as a 400 with body:
+			//    {
+			//      "success":false,
+			//      "error":"Bad request",
+			//      "error_info":"Please check developers.pipedrive.com for more information about Pipedrive API.",
+			//      "data":null,
+			//      "additional_data":null
+			//    }
+			//
+			// We want to emulate this behavior to make sure our CollectionItem callback handles it properly.  When a
+			// item.save(callbackFn) call is made, the callbackFn should have the opportunity to handle this error.
+			var restError = new Error('Pipedrive API error:Bad request');
+			restHandlerMock.editItem.callsFake(function(id, kind, changedData, callbackFn) {
+				callbackFn(restError, null, null);
+			});
+
+			// For purposes of this test, we don't need to do anything in our callback, but we MUST ensure that we get
+			// called back.  Without getting the error object passed to it, we can't respond to the rejected input.
+			var saveCallback = sinon.spy();
+			item.save(saveCallback);
+
+			sinon.assert.calledWith(restHandlerMock.editItem, 1, 'deals', {'badFieldId': 'Ignored value'});
+			sinon.assert.calledOnce(saveCallback);
+			sinon.assert.calledWith(saveCallback, restError);
+
+			restHandlerMock.editItem.resetBehavior();
 		});
 	});
 });


### PR DESCRIPTION
_I didn't see any contributor guidelines, but trying this anyway because the issue is a showstopper for us (since the uncaught error crashes Node)._

Fixes #74.

### Problem
When item.save(callbackFn) is called with invalid input, the server rejects the request with a 400 response, as expected. The client, however, does not call the given callbackFn to provide the error to the caller. Instead, an uncaught error is thrown trying to wrap the `null` data into a collection.

Not only does this behavior violate the specified contract by not calling the callback function, but the uncaught error can crash Node completely, with no way for an outsider to `try`/`catch` the save() call itself, since the error happens in its own callback.

This fix adds unit tests demonstrating the problem, and fixes the problem by only wrapping non-`null` response `data`.

### To Reproduce
In issue #74 several people have described scenarios that led to this problem.  One summary from @JohannesHome in the issue:
> As a follow up. I was able to reproduce the issue finally, and the delete was unrelated to my problem but a http error of `4xx` group as this issue relates to.
> 
> We basically have a situation where we do a `object.save(handler)` call when nothing was changed in the object. In this case the client is doing a `put` with an empty object `{}` as no value has changed, and the server response with `400`.
> 
> The main issue is, therefore, that [save](https://github.com/pipedrive/client-nodejs/blob/768fe160103cb5537c5e4266de5f58f4ab40241e/lib/CollectionItem.js#L25-L28), [merge](https://github.com/pipedrive/client-nodejs/blob/768fe160103cb5537c5e4266de5f58f4ab40241e/lib/CollectionItem.js#L43-L46) and [duplicate](https://github.com/pipedrive/client-nodejs/blob/768fe160103cb5537c5e4266de5f58f4ab40241e/lib/CollectionItem.js#L43-L46) do not propagate the error to the handler, but instead try to access `data`. All these functions generate the same mentioned error in case the server response with anything else besides `200` containing an empty body.
> 
> This should be easy to fix.

More specific repro scenarios include [trying to save() a Person who has already been deleted](https://github.com/pipedrive/client-nodejs/issues/74#issue-330109982) (@super-cache-money) and [setting an invalid field ID before save()](https://github.com/pipedrive/client-nodejs/issues/74#issuecomment-429311662) (@vasiabikeru).

### Summary
Please consider merging this into the API client to fix what appears to be a very major problem.
