### PR TITLE
Bump version to release vulnerability fixes and error handling fix.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pipedrive",
-  "version": "6.0.3",
+  "version": "6.0.4",
   "description": "Pipedrive REST client for NodeJS",
   "keywords": [
     "pipedrive",


### PR DESCRIPTION
Fixed have been introduced in PRs #85 and #86 that have not been released via NPM.  This changes the version to 6.0.4 so that it can be `npm publish`ed.
