### PR TITLE
Dynamic deal fields support

### DIFF
--- a/lib/Controllers/DealsController.js
+++ b/lib/Controllers/DealsController.js
@@ -775,7 +775,6 @@ class DealsController {
                         _reject(errorResponse.error);
                     } else if (_response.statusCode >= 200 && _response.statusCode <= 206) {
                         let parsed = JSON.parse(_response.body);
-                        parsed = _baseController.getObjectMapper().mapObject(parsed, 'GetDeal');
                         _callback(null, parsed, _context);
                         _fulfill(parsed);
                     } else {
@@ -888,15 +887,29 @@ class DealsController {
             visible_to: (input.visibleTo !== null) ? input.visibleTo : null,
         };
 
+        input.title = undefined;
+        input.value = undefined;
+        input.currency = undefined;
+        input.userId = undefined;
+        input.personId = undefined;
+        input.orgId = undefined;
+        input.stageId = undefined;
+        input.status = undefined;
+        input.probability = undefined;
+        input.lostReason = undefined;
+        input.visibleTo = undefined;
+
+        const _formWithDynamicFields = { ..._form, ...input};
+
         // remove null values
-        _apiHelper.cleanObject(_form);
+        _apiHelper.cleanObject(_formWithDynamicFields);
 
         // construct the request
         const _options = {
             queryUrl: _queryUrl,
             method: 'PUT',
             headers: _headers,
-            form: _form,
+            form: _formWithDynamicFields,
         };
 
         // build the response processing.
@@ -913,7 +926,6 @@ class DealsController {
                         _reject(errorResponse.error);
                     } else if (_response.statusCode >= 200 && _response.statusCode <= 206) {
                         let parsed = JSON.parse(_response.body);
-                        parsed = _baseController.getObjectMapper().mapObject(parsed, 'GetAddedDeal');
                         _callback(null, parsed, _context);
                         _fulfill(parsed);
                     } else {


### PR DESCRIPTION
Removed parsing of getDetailsOfADealAction to make it possible to see dynamic fields.

Added dynamic field update support using spread operators in updateADealAction method.

This PR should fix issue #114 