### PR TITLE
Deleted misleading docs

### DIFF
--- a/lib/Controllers/PersonsController.js
+++ b/lib/Controllers/PersonsController.js
@@ -205,7 +205,6 @@ class PersonsController {
      * exists, fetch the personFields and look for 'key' values.
      *
      * @param  {array}  input    Array with all options for search
-     * @param {string} input['contentType'] (optional) TODO: type description here
      * @param {object} input['body'] (optional) TODO: type description here
      *
      * @callback    The callback function that returns response from the API call


### PR DESCRIPTION
This PR deletes docs about an attribute that breaks addAPerson method. Did not fix in code right now to reduce merge errors.

This was created in response to issue #129 