### PR TITLE
Issue - 138, remove JSON.parse for file's response

### DIFF
--- a/lib/Controllers/FilesController.js
+++ b/lib/Controllers/FilesController.js
@@ -740,6 +740,7 @@ class FilesController {
             queryUrl: _queryUrl,
             method: 'GET',
             headers: _headers,
+            encoding: null,
         };
 
         // build the response processing.
@@ -755,9 +756,8 @@ class FilesController {
                             errorResponse.context);
                         _reject(errorResponse.error);
                     } else if (_response.statusCode >= 200 && _response.statusCode <= 206) {
-                        const parsed = JSON.parse(_response.body);
-                        _callback(null, parsed, _context);
-                        _fulfill(parsed);
+                        _callback(null, _response.body, _context);
+                        _fulfill(_response.body);
                     } else {
                         errorResponse = _baseController.validateResponse(_context);
                         _callback(errorResponse.error,

--- a/lib/Http/Client/RequestClient.js
+++ b/lib/Http/Client/RequestClient.js
@@ -20,6 +20,9 @@ const convertHttpRequest = function convertHttpRequest(req) {
         headers: req.headers,
         followAllRedirects: true,
     };
+    if (req.hasOwnProperty('encoding')) {
+        options.encoding = req.encoding;
+    }
     if (req.username) {
         options.auth = { user: req.username, pass: req.password };
     }


### PR DESCRIPTION
Issue: https://github.com/pipedrive/client-nodejs/issues/138

Details:
`/files/{id}/download` used to invoke `JSON.parse` for response body. In case if a respone is some binary (file) JSON.parse  will fail.

Test fix:
```javascript
const Pipedrive = require('../client-nodejs');  // fix-files branch
const API_TOKEN = 'token'; // replace to yours
const FILE_ID = 'file id you want to download'; // replace to yours
const fs = require('fs')
const path = require('path')

Pipedrive.Configuration.apiToken = API_TOKEN;

function getFile(fileId) {
    return new Promise((resolve, reject) => {
        Pipedrive.FilesController.getDownloadOneFile(fileId, (err, res) => {
            if (err) {
                reject(err)
            } else {
                resolve(res);
            }
        })
    });
}
async function test() {
    try {
        const response = await getFile(FILE_ID);
        
        fs.writeFileSync(
            path.resolve(__dirname, 'response_file'),
            response,
        )
        console.log('done')
    } catch (err) {
        console.log('err', err);
    }
}
test() 
```