### PR TITLE
Security: remove unused 'fs' dependency, which is already provided by Node.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -984,11 +984,6 @@
         "mime-types": "^2.1.12"
       }
     },
-    "fs": {
-      "version": "0.0.1-security",
-      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
-      "integrity": "sha1-invTcYa23d84E/I4WLV+yq9eQdQ="
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
   },
   "dependencies": {
     "moment": "^2.17.1",
-    "request": "^2.55.0",
-    "fs": "0.0.1-security"
+    "request": "^2.55.0"
   },
   "eslintConfig": {
     "extends": "airbnb",


### PR DESCRIPTION
This avoids the download and runtime use of a security holding package.

As a somewhat-related security aside, given this package is published to npm, you might want to consider removing the `package-lock.json` file from the repo as these can rather quickly fall out of date. For example, the current file contains entries for versions of `lodash` and `y18n` with known vulnerabilities.