### PR TITLE
GRAM-1790 Add @babel/runtime as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@babel/cli": "^7.0.0",
+    "@babel/runtime": "^7.14.0",
     "superagent": "^5.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Problem
- https://pipedrive.atlassian.net/browse/GRAM-1790

## Changes
- Added `@babel/runtime` as a dependency (as the name suggest it is required at runtime)