### PR TITLE
Added opts manually if it does not exist

### DIFF
--- a/docs/PostRoleSettingsAllOfData.md
+++ b/docs/PostRoleSettingsAllOfData.md
@@ -20,8 +20,6 @@ Name | Type | Description | Notes
 
 * `null` (value: `null`)
 
-* `null` (value: `null`)
-
 
 
 

--- a/docs/RoleSettings.md
+++ b/docs/RoleSettings.md
@@ -5,7 +5,6 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **dealDefaultVisibility** | **Number** | The default visibility level of the Deals for the Role | [optional] 
-**leadDefaultVisibility** | **Number** | The default visibility level of the Leads for the Role | [optional] 
 **orgDefaultVisibility** | **Number** | The default visibility level of the Organizations for the Role | [optional] 
 **personDefaultVisibility** | **Number** | The default visibility level of the People for the Role | [optional] 
 **productDefaultVisibility** | **Number** | The default visibility level of the Products for the Role | [optional] 

--- a/src/api/ActivitiesApi.js
+++ b/src/api/ActivitiesApi.js
@@ -112,6 +112,7 @@ export default class ActivitiesApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/DeleteActivitiesResponse200} and HTTP response
      */
     deleteActivitiesWithHttpInfo(ids) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'ids' is set
       if (ids === undefined || ids === null) {
@@ -176,6 +177,7 @@ export default class ActivitiesApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/DeleteActivityResponse200} and HTTP response
      */
     deleteActivityWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -324,6 +326,7 @@ export default class ActivitiesApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/GetActivityResponse200} and HTTP response
      */
     getActivityWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {

--- a/src/api/ActivityFieldsApi.js
+++ b/src/api/ActivityFieldsApi.js
@@ -41,6 +41,7 @@ export default class ActivityFieldsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/FieldsResponse} and HTTP response
      */
     getActivityFieldsWithHttpInfo() {
+      const opts = {}
       let postBody = null;
 
       let pathParams = {

--- a/src/api/ActivityTypesApi.js
+++ b/src/api/ActivityTypesApi.js
@@ -125,6 +125,7 @@ export default class ActivityTypesApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/ActivityTypeCreateUpdateDeleteResponse} and HTTP response
      */
     deleteActivityTypeWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -189,6 +190,7 @@ export default class ActivityTypesApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/ActivityTypeBulkDeleteResponse} and HTTP response
      */
     deleteActivityTypesWithHttpInfo(ids) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'ids' is set
       if (ids === undefined || ids === null) {
@@ -252,6 +254,7 @@ export default class ActivityTypesApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/ActivityTypeListResponse} and HTTP response
      */
     getActivityTypesWithHttpInfo() {
+      const opts = {}
       let postBody = null;
 
       let pathParams = {

--- a/src/api/CallLogsApi.js
+++ b/src/api/CallLogsApi.js
@@ -112,6 +112,7 @@ export default class CallLogsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/BaseResponse} and HTTP response
      */
     addCallLogAudioFileWithHttpInfo(id, file) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -183,6 +184,7 @@ export default class CallLogsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/BaseResponse} and HTTP response
      */
     deleteCallLogWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -247,6 +249,7 @@ export default class CallLogsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/BaseResponse} and HTTP response
      */
     getCallLogWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {

--- a/src/api/DealFieldsApi.js
+++ b/src/api/DealFieldsApi.js
@@ -122,6 +122,7 @@ export default class DealFieldsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/DeleteResponse} and HTTP response
      */
     deleteDealFieldWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -186,6 +187,7 @@ export default class DealFieldsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/BulkDeleteResponse} and HTTP response
      */
     deleteDealFieldsWithHttpInfo(ids) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'ids' is set
       if (ids === undefined || ids === null) {
@@ -250,6 +252,7 @@ export default class DealFieldsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/FieldResponse} and HTTP response
      */
     getDealFieldWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -313,6 +316,7 @@ export default class DealFieldsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/FieldsResponse} and HTTP response
      */
     getDealFieldsWithHttpInfo() {
+      const opts = {}
       let postBody = null;
 
       let pathParams = {

--- a/src/api/DealsApi.js
+++ b/src/api/DealsApi.js
@@ -185,6 +185,7 @@ export default class DealsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/AddedDealFollower} and HTTP response
      */
     addDealFollowerWithHttpInfo(id, userId) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -257,6 +258,7 @@ export default class DealsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/PostDealParticipants} and HTTP response
      */
     addDealParticipantWithHttpInfo(id, personId) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -397,6 +399,7 @@ export default class DealsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/DeleteDeal} and HTTP response
      */
     deleteDealWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -462,6 +465,7 @@ export default class DealsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/DeleteDealFollower} and HTTP response
      */
     deleteDealFollowerWithHttpInfo(id, followerId) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -533,6 +537,7 @@ export default class DealsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/DeleteDealParticipant} and HTTP response
      */
     deleteDealParticipantWithHttpInfo(id, dealParticipantId) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -604,6 +609,7 @@ export default class DealsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/DeleteDealProduct} and HTTP response
      */
     deleteDealProductWithHttpInfo(id, productAttachmentId) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -674,6 +680,7 @@ export default class DealsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/DeleteMultipleDeals} and HTTP response
      */
     deleteDealsWithHttpInfo(ids) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'ids' is set
       if (ids === undefined || ids === null) {
@@ -738,6 +745,7 @@ export default class DealsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/GetDuplicatedDeal} and HTTP response
      */
     duplicateDealWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -802,6 +810,7 @@ export default class DealsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/GetDeal} and HTTP response
      */
     getDealWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -1024,6 +1033,7 @@ export default class DealsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/ListFollowersResponse} and HTTP response
      */
     getDealFollowersWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -1462,6 +1472,7 @@ export default class DealsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/ListPermittedUsersResponse} and HTTP response
      */
     getDealUsersWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -1859,6 +1870,7 @@ export default class DealsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/GetMergedDeal} and HTTP response
      */
     mergeDealsWithHttpInfo(id, mergeWithId) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {

--- a/src/api/FilesApi.js
+++ b/src/api/FilesApi.js
@@ -141,6 +141,7 @@ export default class FilesApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/CreateRemoteFileAndLinkItToItem} and HTTP response
      */
     addFileAndLinkItWithHttpInfo(fileType, title, itemType, itemId, remoteLocation) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'fileType' is set
       if (fileType === undefined || fileType === null) {
@@ -234,6 +235,7 @@ export default class FilesApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/DeleteFile} and HTTP response
      */
     deleteFileWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -298,6 +300,7 @@ export default class FilesApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link File} and HTTP response
      */
     downloadFileWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -362,6 +365,7 @@ export default class FilesApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/GetOneFile} and HTTP response
      */
     getFileWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -501,6 +505,7 @@ export default class FilesApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/LinkRemoteFileToItem} and HTTP response
      */
     linkFileToItemWithHttpInfo(itemType, itemId, remoteId, remoteLocation) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'itemType' is set
       if (itemType === undefined || itemType === null) {

--- a/src/api/FiltersApi.js
+++ b/src/api/FiltersApi.js
@@ -111,6 +111,7 @@ export default class FiltersApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/FiltersDeleteResponse} and HTTP response
      */
     deleteFilterWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -175,6 +176,7 @@ export default class FiltersApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/FiltersBulkDeleteResponse} and HTTP response
      */
     deleteFiltersWithHttpInfo(ids) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'ids' is set
       if (ids === undefined || ids === null) {
@@ -239,6 +241,7 @@ export default class FiltersApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/FiltersGetResponse} and HTTP response
      */
     getFilterWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -302,6 +305,7 @@ export default class FiltersApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link Object} and HTTP response
      */
     getFilterHelpersWithHttpInfo() {
+      const opts = {}
       let postBody = null;
 
       let pathParams = {

--- a/src/api/GlobalMessagesApi.js
+++ b/src/api/GlobalMessagesApi.js
@@ -43,6 +43,7 @@ export default class GlobalMessagesApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/GlobalMessageDelete} and HTTP response
      */
     deleteGlobalMessageWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {

--- a/src/api/GoalsApi.js
+++ b/src/api/GoalsApi.js
@@ -129,6 +129,7 @@ export default class GoalsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/DeleteGoalResponse200} and HTTP response
      */
     deleteGoalWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -195,6 +196,7 @@ export default class GoalsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/GetGoalResultResponse200} and HTTP response
      */
     getGoalResultWithHttpInfo(id, periodStart, periodEnd) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {

--- a/src/api/LeadLabelsApi.js
+++ b/src/api/LeadLabelsApi.js
@@ -109,6 +109,7 @@ export default class LeadLabelsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/LeadIdResponse200} and HTTP response
      */
     deleteLeadLabelWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -172,6 +173,7 @@ export default class LeadLabelsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/GetLeadLabelsResponse200} and HTTP response
      */
     getLeadLabelsWithHttpInfo() {
+      const opts = {}
       let postBody = null;
 
       let pathParams = {

--- a/src/api/LeadSourcesApi.js
+++ b/src/api/LeadSourcesApi.js
@@ -41,6 +41,7 @@ export default class LeadSourcesApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/GetLeadSourcesResponse200} and HTTP response
      */
     getLeadSourcesWithHttpInfo() {
+      const opts = {}
       let postBody = null;
 
       let pathParams = {

--- a/src/api/LeadsApi.js
+++ b/src/api/LeadsApi.js
@@ -109,6 +109,7 @@ export default class LeadsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/LeadIdResponse200} and HTTP response
      */
     deleteLeadWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -173,6 +174,7 @@ export default class LeadsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/OneLeadResponse200} and HTTP response
      */
     getLeadWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {

--- a/src/api/MailboxApi.js
+++ b/src/api/MailboxApi.js
@@ -49,6 +49,7 @@ export default class MailboxApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/MailThreadDelete} and HTTP response
      */
     deleteMailThreadWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -183,6 +184,7 @@ export default class MailboxApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/MailThreadOne} and HTTP response
      */
     getMailThreadWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -247,6 +249,7 @@ export default class MailboxApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/MailThreadMessages} and HTTP response
      */
     getMailThreadMessagesWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {

--- a/src/api/NoteFieldsApi.js
+++ b/src/api/NoteFieldsApi.js
@@ -41,6 +41,7 @@ export default class NoteFieldsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/NoteFieldsResponse} and HTTP response
      */
     getNoteFieldsWithHttpInfo() {
+      const opts = {}
       let postBody = null;
 
       let pathParams = {

--- a/src/api/NotesApi.js
+++ b/src/api/NotesApi.js
@@ -153,6 +153,7 @@ export default class NotesApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/DeleteNote} and HTTP response
      */
     deleteNoteWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -217,6 +218,7 @@ export default class NotesApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/PostNote} and HTTP response
      */
     getNoteWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {

--- a/src/api/OrganizationFieldsApi.js
+++ b/src/api/OrganizationFieldsApi.js
@@ -122,6 +122,7 @@ export default class OrganizationFieldsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/DeleteResponse} and HTTP response
      */
     deleteOrganizationFieldWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -186,6 +187,7 @@ export default class OrganizationFieldsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/BulkDeleteResponse} and HTTP response
      */
     deleteOrganizationFieldsWithHttpInfo(ids) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'ids' is set
       if (ids === undefined || ids === null) {
@@ -250,6 +252,7 @@ export default class OrganizationFieldsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/FieldResponse} and HTTP response
      */
     getOrganizationFieldWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -313,6 +316,7 @@ export default class OrganizationFieldsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/FieldsResponse} and HTTP response
      */
     getOrganizationFieldsWithHttpInfo() {
+      const opts = {}
       let postBody = null;
 
       let pathParams = {

--- a/src/api/OrganizationRelationshipsApi.js
+++ b/src/api/OrganizationRelationshipsApi.js
@@ -122,6 +122,7 @@ export default class OrganizationRelationshipsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/OrganizationRelationshipDeleteResponse} and HTTP response
      */
     deleteOrganizationRelationshipWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -186,6 +187,7 @@ export default class OrganizationRelationshipsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/AllOrganizationRelationshipsGetResponse} and HTTP response
      */
     getOrganizationRelationShipsWithHttpInfo(orgId) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'orgId' is set
       if (orgId === undefined || orgId === null) {

--- a/src/api/OrganizationsApi.js
+++ b/src/api/OrganizationsApi.js
@@ -138,6 +138,7 @@ export default class OrganizationsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/OrganizationFollowerPostResponse} and HTTP response
      */
     addOrganizationFollowerWithHttpInfo(id, userId) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -209,6 +210,7 @@ export default class OrganizationsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/OrganizationDeleteResponse} and HTTP response
      */
     deleteOrganizationWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -274,6 +276,7 @@ export default class OrganizationsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/OrganizationFollowerDeleteResponse} and HTTP response
      */
     deleteOrganizationFollowerWithHttpInfo(id, followerId) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -344,6 +347,7 @@ export default class OrganizationsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/OrganizationsDeleteResponse} and HTTP response
      */
     deleteOrganizationsWithHttpInfo(ids) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'ids' is set
       if (ids === undefined || ids === null) {
@@ -408,6 +412,7 @@ export default class OrganizationsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/OrganizationDetailsGetResponse} and HTTP response
      */
     getOrganizationWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -785,6 +790,7 @@ export default class OrganizationsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/OrganizationFollowersListResponse} and HTTP response
      */
     getOrganizationFollowersWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -1074,6 +1080,7 @@ export default class OrganizationsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/ListPermittedUsersResponse1} and HTTP response
      */
     getOrganizationUsersWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -1217,6 +1224,7 @@ export default class OrganizationsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/OrganizationsMergeResponse} and HTTP response
      */
     mergeOrganizationsWithHttpInfo(id, mergeWithId) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {

--- a/src/api/PermissionSetsApi.js
+++ b/src/api/PermissionSetsApi.js
@@ -43,6 +43,7 @@ export default class PermissionSetsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/SinglePermissionSetsItem} and HTTP response
      */
     getPermissionSetWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -177,6 +178,7 @@ export default class PermissionSetsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/PermissionSets} and HTTP response
      */
     getPermissionSetsWithHttpInfo() {
+      const opts = {}
       let postBody = null;
 
       let pathParams = {

--- a/src/api/PersonFieldsApi.js
+++ b/src/api/PersonFieldsApi.js
@@ -122,6 +122,7 @@ export default class PersonFieldsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/DeleteResponse} and HTTP response
      */
     deletePersonFieldWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -186,6 +187,7 @@ export default class PersonFieldsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/BulkDeleteResponse} and HTTP response
      */
     deletePersonFieldsWithHttpInfo(ids) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'ids' is set
       if (ids === undefined || ids === null) {
@@ -250,6 +252,7 @@ export default class PersonFieldsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/FieldResponse} and HTTP response
      */
     getPersonFieldWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -313,6 +316,7 @@ export default class PersonFieldsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/FieldsResponse} and HTTP response
      */
     getPersonFieldsWithHttpInfo() {
+      const opts = {}
       let postBody = null;
 
       let pathParams = {

--- a/src/api/PersonsApi.js
+++ b/src/api/PersonsApi.js
@@ -125,6 +125,7 @@ export default class PersonsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/AddFollowerToPersonResponse} and HTTP response
      */
     addPersonFollowerWithHttpInfo(id, userId) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -287,6 +288,7 @@ export default class PersonsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/DeletePersonResponse} and HTTP response
      */
     deletePersonWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -352,6 +354,7 @@ export default class PersonsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/DeletePersonResponse} and HTTP response
      */
     deletePersonFollowerWithHttpInfo(id, followerId) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -422,6 +425,7 @@ export default class PersonsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/DeletePersonResponse} and HTTP response
      */
     deletePersonPictureWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -628,6 +632,7 @@ export default class PersonsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/GetPersonDetailsResponse} and HTTP response
      */
     getPersonWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -929,6 +934,7 @@ export default class PersonsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/ListFollowersResponse} and HTTP response
      */
     getPersonFollowersWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -1218,6 +1224,7 @@ export default class PersonsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/ListPermittedUsersResponse1} and HTTP response
      */
     getPersonUsersWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -1361,6 +1368,7 @@ export default class PersonsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/MergePersonsResponse} and HTTP response
      */
     mergePersonsWithHttpInfo(id, mergeWithId) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {

--- a/src/api/PipelinesApi.js
+++ b/src/api/PipelinesApi.js
@@ -126,6 +126,7 @@ export default class PipelinesApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/DeletePipelineResponse200} and HTTP response
      */
     deletePipelineWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -518,6 +519,7 @@ export default class PipelinesApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/GetAllPipelines} and HTTP response
      */
     getPipelinesWithHttpInfo() {
+      const opts = {}
       let postBody = null;
 
       let pathParams = {

--- a/src/api/ProductFieldsApi.js
+++ b/src/api/ProductFieldsApi.js
@@ -110,6 +110,7 @@ export default class ProductFieldsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/DeleteProductFieldResponse} and HTTP response
      */
     deleteProductFieldWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -174,6 +175,7 @@ export default class ProductFieldsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/DeleteMultipleProductFieldsResponse} and HTTP response
      */
     deleteProductFieldsWithHttpInfo(ids) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'ids' is set
       if (ids === undefined || ids === null) {
@@ -238,6 +240,7 @@ export default class ProductFieldsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/GetProductFieldResponse} and HTTP response
      */
     getProductFieldWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -301,6 +304,7 @@ export default class ProductFieldsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/GetAllProductFieldsResponse} and HTTP response
      */
     getProductFieldsWithHttpInfo() {
+      const opts = {}
       let postBody = null;
 
       let pathParams = {

--- a/src/api/ProductsApi.js
+++ b/src/api/ProductsApi.js
@@ -186,6 +186,7 @@ export default class ProductsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/DeleteProductResponse} and HTTP response
      */
     deleteProductWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -251,6 +252,7 @@ export default class ProductsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/DeleteProductFollowerResponse} and HTTP response
      */
     deleteProductFollowerWithHttpInfo(id, followerId) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -397,6 +399,7 @@ export default class ProductsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/ProductResponse} and HTTP response
      */
     getProductWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -616,6 +619,7 @@ export default class ProductsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/UserIDs} and HTTP response
      */
     getProductFollowersWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -680,6 +684,7 @@ export default class ProductsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/UserIDs} and HTTP response
      */
     getProductUsersWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {

--- a/src/api/RolesApi.js
+++ b/src/api/RolesApi.js
@@ -54,6 +54,7 @@ export default class RolesApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/PostRoleSettings} and HTTP response
      */
     addOrUpdateRoleSettingWithHttpInfo(id, settingKey, value) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -198,6 +199,7 @@ export default class RolesApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/PostRoleAssignment} and HTTP response
      */
     addRoleAssignmentWithHttpInfo(id, userId) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -268,6 +270,7 @@ export default class RolesApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/DeleteRole} and HTTP response
      */
     deleteRoleWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -332,6 +335,7 @@ export default class RolesApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/DeleteRoleAssignment} and HTTP response
      */
     deleteRoleAssignmentWithHttpInfo(id, userId) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -401,6 +405,7 @@ export default class RolesApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/GetRole} and HTTP response
      */
     getRoleWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -536,6 +541,7 @@ export default class RolesApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/GetRoleSettings} and HTTP response
      */
     getRoleSettingsWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {

--- a/src/api/StagesApi.js
+++ b/src/api/StagesApi.js
@@ -128,6 +128,7 @@ export default class StagesApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/DeleteStageResponse200} and HTTP response
      */
     deleteStageWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -192,6 +193,7 @@ export default class StagesApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/DeleteStagesResponse200} and HTTP response
      */
     deleteStagesWithHttpInfo(ids) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'ids' is set
       if (ids === undefined || ids === null) {
@@ -256,6 +258,7 @@ export default class StagesApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/GetOneStage} and HTTP response
      */
     getStageWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {

--- a/src/api/SubscriptionsApi.js
+++ b/src/api/SubscriptionsApi.js
@@ -241,6 +241,7 @@ export default class SubscriptionsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/SubscriptionsIdResponse} and HTTP response
      */
     deleteSubscriptionWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -305,6 +306,7 @@ export default class SubscriptionsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/SubscriptionsIdResponse} and HTTP response
      */
     findSubscriptionByDealWithHttpInfo(dealId) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'dealId' is set
       if (dealId === undefined || dealId === null) {
@@ -369,6 +371,7 @@ export default class SubscriptionsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/SubscriptionsIdResponse} and HTTP response
      */
     getSubscriptionWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -433,6 +436,7 @@ export default class SubscriptionsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/PaymentsResponse} and HTTP response
      */
     getSubscriptionPaymentsWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {

--- a/src/api/TeamsApi.js
+++ b/src/api/TeamsApi.js
@@ -319,6 +319,7 @@ export default class TeamsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/UserIDs} and HTTP response
      */
     getTeamUsersWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {

--- a/src/api/UserConnectionsApi.js
+++ b/src/api/UserConnectionsApi.js
@@ -42,6 +42,7 @@ export default class UserConnectionsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/UserConnections} and HTTP response
      */
     getUserConnectionsWithHttpInfo() {
+      const opts = {}
       let postBody = null;
 
       let pathParams = {

--- a/src/api/UserSettingsApi.js
+++ b/src/api/UserSettingsApi.js
@@ -42,6 +42,7 @@ export default class UserSettingsApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/UserSettings} and HTTP response
      */
     getUserSettingsWithHttpInfo() {
+      const opts = {}
       let postBody = null;
 
       let pathParams = {

--- a/src/api/UsersApi.js
+++ b/src/api/UsersApi.js
@@ -55,6 +55,7 @@ export default class UsersApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/User} and HTTP response
      */
     addUserWithHttpInfo(name, email, activeFlag) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'name' is set
       if (name === undefined || name === null) {
@@ -135,6 +136,7 @@ export default class UsersApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link Object} and HTTP response
      */
     addUserBlacklistedEmailWithHttpInfo(id, address) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -207,6 +209,7 @@ export default class UsersApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/PostRoleAssignment} and HTTP response
      */
     addUserRoleAssignmentWithHttpInfo(id, roleId) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -279,6 +282,7 @@ export default class UsersApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/DeleteRoleAssignment} and HTTP response
      */
     deleteUserRoleAssignmentWithHttpInfo(id, roleId) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -418,6 +422,7 @@ export default class UsersApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/UserMe} and HTTP response
      */
     getCurrentUserWithHttpInfo() {
+      const opts = {}
       let postBody = null;
 
       let pathParams = {
@@ -476,6 +481,7 @@ export default class UsersApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/User} and HTTP response
      */
     getUserWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -540,6 +546,7 @@ export default class UsersApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link Object} and HTTP response
      */
     getUserBlacklistedEmailsWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -604,6 +611,7 @@ export default class UsersApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/UserIDs} and HTTP response
      */
     getUserFollowersWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -668,6 +676,7 @@ export default class UsersApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/UserPermissions} and HTTP response
      */
     getUserPermissionsWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -805,6 +814,7 @@ export default class UsersApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/GetRoleSettings} and HTTP response
      */
     getUserRoleSettingsWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -868,6 +878,7 @@ export default class UsersApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/Users} and HTTP response
      */
     getUsersWithHttpInfo() {
+      const opts = {}
       let postBody = null;
 
       let pathParams = {
@@ -927,6 +938,7 @@ export default class UsersApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/User} and HTTP response
      */
     updateUserWithHttpInfo(id, activeFlag) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {

--- a/src/api/WebhooksApi.js
+++ b/src/api/WebhooksApi.js
@@ -143,6 +143,7 @@ export default class WebhooksApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/BaseResponseWithStatus} and HTTP response
      */
     deleteWebhookWithHttpInfo(id) {
+      const opts = {}
       let postBody = null;
       // verify the required parameter 'id' is set
       if (id === undefined || id === null) {
@@ -206,6 +207,7 @@ export default class WebhooksApi {
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/Webhooks} and HTTP response
      */
     getWebhooksWithHttpInfo() {
+      const opts = {}
       let postBody = null;
 
       let pathParams = {

--- a/src/model/PostRoleSettingsAllOfData.js
+++ b/src/model/PostRoleSettingsAllOfData.js
@@ -115,12 +115,6 @@ PostRoleSettingsAllOfData['DealDefaultVisibilityEnum'] = {
      * value: null
      * @const
      */
-    "null": null,
-
-    /**
-     * value: null
-     * @const
-     */
     "null": null
 };
 

--- a/src/model/RoleSettings.js
+++ b/src/model/RoleSettings.js
@@ -53,11 +53,6 @@ class RoleSettings {
 
                 delete data['deal_default_visibility'];
             }
-            if (data.hasOwnProperty('lead_default_visibility')) {
-                obj['lead_default_visibility'] = ApiClient.convertToType(data['lead_default_visibility'], 'Number');
-
-                delete data['lead_default_visibility'];
-            }
             if (data.hasOwnProperty('org_default_visibility')) {
                 obj['org_default_visibility'] = ApiClient.convertToType(data['org_default_visibility'], 'Number');
 
@@ -110,12 +105,6 @@ class RoleSettings {
  * @member {Number} deal_default_visibility
  */
 RoleSettings.prototype['deal_default_visibility'] = undefined;
-
-/**
- * The default visibility level of the Leads for the Role
- * @member {Number} lead_default_visibility
- */
-RoleSettings.prototype['lead_default_visibility'] = undefined;
 
 /**
  * The default visibility level of the Organizations for the Role


### PR DESCRIPTION
## Related PRs
- https://github.com/pipedrive/client-nodejs/pull/202
- https://github.com/pipedrive/client-nodejs/pull/198

- In above PRs we added some custom code which breaks if the opts object is not available
- In this PR, we are manually adding it if it doesn't exist
- We can also just not add the custom code if the object does not exist but there is a bug/issue with required JSON body parameters which makes all json params optional (even the required ones)
     - To avoid all of this confusion it is better to just add it manually