### PR TITLE
CTL-2051 respect rate limiting

### DIFF
--- a/lib/Http/Client/RequestClient.js
+++ b/lib/Http/Client/RequestClient.js
@@ -11,6 +11,7 @@ const HttpResponse = require('../Response/HttpResponse');
 const request = require('request');
 const APIHelper = require('../../APIHelper');
 const _configuration = require('../../configuration');
+const cache = require('../../cache');
 
 // convert to request's version of http request
 const convertHttpRequest = function convertHttpRequest(req) {
@@ -38,7 +39,7 @@ const convertHttpRequest = function convertHttpRequest(req) {
         options.headers['content-type'] = 'application/x-www-form-urlencoded';
     }
     if (_configuration.apiToken) {
-        options.qs = { api_token: _configuration.apiToken }
+        options.qs = { api_token: _configuration.apiToken };
     }
     return options;
 };
@@ -79,10 +80,27 @@ const executeRequest = function executeRequest(req, callback) {
     const context = new HttpContext();
     context.request = req;
 
+    const cachedBlock = cache.getRateLimitRes();
+
+    if (cachedBlock) {
+        return callback(cachedBlock.error, cache.getRateLimitRes(), {
+            ...context,
+            response: cachedBlock.response,
+        });
+    }
+
     // make a temp callback
     const internalCallback = function cb(error, res) {
         const response = convertHttpResponse(res);
         context.response = response;
+
+        if (response.statusCode === 429) {
+          cache.setRateLimitRes(Number(response.headers['x-ratelimit-reset']), {
+            error,
+            response,
+          });
+        }
+        
         callback(error, response, context);
     };
 

--- a/lib/Http/Client/RequestClient.js
+++ b/lib/Http/Client/RequestClient.js
@@ -97,7 +97,7 @@ const executeRequest = function executeRequest(req, callback) {
         context.response = response;
 
         if (response.statusCode === 429) {
-            cache.setRateLimitRes(Number(response.headers['retry-after']), {
+            cache.setRateLimitRes(response.headers['retry-after'], {
                 error,
                 response,
             });

--- a/lib/Http/Client/RequestClient.js
+++ b/lib/Http/Client/RequestClient.js
@@ -83,7 +83,7 @@ const executeRequest = function executeRequest(req, callback) {
     const cachedBlock = cache.getRateLimitRes();
 
     if (cachedBlock) {
-        callback(cachedBlock.error, cache.getRateLimitRes(), {
+        callback(cachedBlock.error, cachedBlock.response, {
             request: context.request,
             response: cachedBlock.response,
         });

--- a/lib/Http/Client/RequestClient.js
+++ b/lib/Http/Client/RequestClient.js
@@ -83,10 +83,12 @@ const executeRequest = function executeRequest(req, callback) {
     const cachedBlock = cache.getRateLimitRes();
 
     if (cachedBlock) {
-        return callback(cachedBlock.error, cache.getRateLimitRes(), {
-            ...context,
+        callback(cachedBlock.error, cache.getRateLimitRes(), {
+            request: context.request,
             response: cachedBlock.response,
         });
+
+        return;
     }
 
     // make a temp callback
@@ -95,12 +97,12 @@ const executeRequest = function executeRequest(req, callback) {
         context.response = response;
 
         if (response.statusCode === 429) {
-          cache.setRateLimitRes(Number(response.headers['x-ratelimit-reset']), {
-            error,
-            response,
-          });
+            cache.setRateLimitRes(Number(response.headers['x-ratelimit-reset']), {
+                error,
+                response,
+            });
         }
-        
+
         callback(error, response, context);
     };
 

--- a/lib/Http/Client/RequestClient.js
+++ b/lib/Http/Client/RequestClient.js
@@ -97,7 +97,7 @@ const executeRequest = function executeRequest(req, callback) {
         context.response = response;
 
         if (response.statusCode === 429) {
-            cache.setRateLimitRes(Number(response.headers['x-ratelimit-reset']), {
+            cache.setRateLimitRes(Number(response.headers['Retry-After']), {
                 error,
                 response,
             });

--- a/lib/Http/Client/RequestClient.js
+++ b/lib/Http/Client/RequestClient.js
@@ -97,7 +97,7 @@ const executeRequest = function executeRequest(req, callback) {
         context.response = response;
 
         if (response.statusCode === 429) {
-            cache.setRateLimitRes(Number(response.headers['Retry-After']), {
+            cache.setRateLimitRes(Number(response.headers['retry-after']), {
                 error,
                 response,
             });

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -15,7 +15,7 @@ const setRateLimitRes = (ttl = MAX_RATE_LIMIT_TTL, value) => {
     }
 
     return false;
-}
+};
 
 const getRateLimitRes = () => {
     return rateLimitCache.get('rateLimit');

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,6 +1,6 @@
 const NodeCache = require('node-cache');
 
-const rateLimitCache = new NodeCache({ stdTTL: 20, checkperiod: 60 });
+const rateLimitCache = new NodeCache({ checkperiod: 60 });
 const MAX_RATE_LIMIT_TTL = 2;
 
 const setRateLimitRes = (ttl = MAX_RATE_LIMIT_TTL, value) => {

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,0 +1,27 @@
+const NodeCache = require('node-cache');
+
+const rateLimitCache = new NodeCache({ stdTTL: 20, checkperiod: 60 });
+const MAX_RATE_LIMIT_TTL = 2;
+
+const setRateLimitRes = (ttl = MAX_RATE_LIMIT_TTL, value) => {
+    const numericTtl = Number(ttl);
+
+    if (numericTtl && numericTtl > 0) {
+        if (numericTtl > MAX_RATE_LIMIT_TTL) {
+            return rateLimitCache.set('rateLimit', value, MAX_RATE_LIMIT_TTL);
+        }
+
+        return rateLimitCache.set('rateLimit', value, numericTtl);
+    }
+
+    return false;
+}
+
+const getRateLimitRes = () => {
+    return rateLimitCache.get('rateLimit');
+};
+
+module.exports = {
+    setRateLimitRes,
+    getRateLimitRes,
+};

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
   },
   "dependencies": {
     "moment": "^2.17.1",
+    "node-cache": "^5.1.2",
+    "proxyquire": "^2.1.3",
     "request": "^2.88.2"
   },
   "eslintConfig": {


### PR DESCRIPTION
Pipedrive API has rate limits and responds with 429 statusCode and also adds the rate limiting related headers in case some limit is exceeded. 

## Changed
* In case of 429 response, the library now caches the response for the amount of time specified with X-RateLimit-Reset header. The maximum cache ttl is set to 2 seconds. For this period of time, all the requests initiated via library will fail with the cached response.