### PR TITLE
GRAL-2141 fix functional tests

### DIFF
--- a/test/functional/access-token.test.js
+++ b/test/functional/access-token.test.js
@@ -4,25 +4,30 @@ const mockServerClient = mockServer.mockServerClient;
 let lib;
 
 describe('oauth2 accessToken', () => {
+	let oauth2;
+	let pdClient;
+	let base64ClientIdAndSecret;
+
+
 	beforeEach(async () => {
 		jest.resetModules();
 
 		lib = require('../../dist');
 
-		await mockServerClient("localhost", 1080, null, false).clear('/oauth/token', 'ALL');
-	});
+		await mockServerClient('localhost', 1080, null, false).clear('/oauth/token', 'ALL');
 
-	it('should refresh accessToken with valid refreshToken', async () => {
-		const pdClient = lib.ApiClient.instance;
-		const oauth2 = pdClient.authentications.oauth2;
+		pdClient = lib.ApiClient.instance;
+		oauth2 = pdClient.authentications.oauth2;
 
 		oauth2.host = 'http://localhost:1080';
 		oauth2.clientId = 'fakeClientId';
 		oauth2.clientSecret = 'fakeClientSecret';
 		oauth2.redirectUri = 'https://example.org';
-		oauth2.refreshToken = 'fakeRefreshToken';
+		base64ClientIdAndSecret = Buffer.from(`${oauth2.clientId}:${oauth2.clientSecret}`).toString('base64');
+	});
 
-		const base64ClientIdAndSecret = Buffer.from(`${oauth2.clientId}:${oauth2.clientSecret}`).toString('base64');
+	it('should refresh accessToken with valid refreshToken', async () => {
+		oauth2.refreshToken = 'fakeRefreshToken';
 
 		await mockServerClient("localhost", 1080, null, false).mockAnyResponse({
 			httpRequest: {
@@ -66,14 +71,6 @@ describe('oauth2 accessToken', () => {
 	});
 
 	it('should throw refreshToken is not set', async () => {
-		const pdClient = lib.ApiClient.instance;
-		const oauth2 = pdClient.authentications.oauth2;
-
-		oauth2.host = 'http://localhost:1080';
-		oauth2.clientId = 'fakeClientId';
-		oauth2.clientSecret = 'fakeClientSecret';
-		oauth2.redirectUri = 'https://example.org';
-
 		try {
 			expect(
 				await pdClient.refreshToken()
@@ -84,16 +81,7 @@ describe('oauth2 accessToken', () => {
 	});
 
 	it('should throw wrong refresh token', async () => {
-		const pdClient = lib.ApiClient.instance;
-		const oauth2 = pdClient.authentications.oauth2;
-
-		oauth2.host = 'http://localhost:1080';
-		oauth2.clientId = 'fakeClientId';
-		oauth2.clientSecret = 'fakeClientSecret';
-		oauth2.redirectUri = 'https://example.org';
 		oauth2.refreshToken = 'wrongRefreshToken';
-
-		const base64ClientIdAndSecret = Buffer.from(`${oauth2.clientId}:${oauth2.clientSecret}`).toString('base64');
 
 		await mockServerClient("localhost", 1080, null, false).mockAnyResponse({
 			httpRequest: {

--- a/test/functional/access-token.test.js
+++ b/test/functional/access-token.test.js
@@ -13,11 +13,25 @@ describe('oauth2 accessToken', () => {
 	});
 
 	it('should refresh accessToken with valid refreshToken', async () => {
+		const pdClient = lib.ApiClient.instance;
+		const oauth2 = pdClient.authentications.oauth2;
+
+		oauth2.host = 'http://localhost:1080';
+		oauth2.clientId = 'fakeClientId';
+		oauth2.clientSecret = 'fakeClientSecret';
+		oauth2.redirectUri = 'https://example.org';
+		oauth2.refreshToken = 'fakeRefreshToken';
+
+		const base64ClientIdAndSecret = Buffer.from(`${oauth2.clientId}:${oauth2.clientSecret}`).toString('base64');
+
 		await mockServerClient("localhost", 1080, null, false).mockAnyResponse({
 			httpRequest: {
 				method: 'POST',
 				path: '/oauth/token',
-				body: 'refresh_token=fakeRefreshToken&client_id=fakeClientId&client_secret=fakeClientSecret&grant_type=refresh_token',
+				body: 'refresh_token=fakeRefreshToken&grant_type=refresh_token',
+				headers: {
+					'Authorization': [`Basic ${base64ClientIdAndSecret}`],
+				},
 			},
 			httpResponse: {
 				statusCode: 200,
@@ -34,15 +48,6 @@ describe('oauth2 accessToken', () => {
 				})
 			},
 		});
-
-		const pdClient = lib.ApiClient.instance;
-		const oauth2 = pdClient.authentications.oauth2;
-
-		oauth2.host = 'http://localhost:1080';
-		oauth2.clientId = 'fakeClientId';
-		oauth2.clientSecret = 'fakeClientSecret';
-		oauth2.redirectUri = 'https://example.org';
-		oauth2.refreshToken = 'fakeRefreshToken';
 
 		const auth = await pdClient.refreshToken();
 
@@ -79,11 +84,25 @@ describe('oauth2 accessToken', () => {
 	});
 
 	it('should throw wrong refresh token', async () => {
+		const pdClient = lib.ApiClient.instance;
+		const oauth2 = pdClient.authentications.oauth2;
+
+		oauth2.host = 'http://localhost:1080';
+		oauth2.clientId = 'fakeClientId';
+		oauth2.clientSecret = 'fakeClientSecret';
+		oauth2.redirectUri = 'https://example.org';
+		oauth2.refreshToken = 'wrongRefreshToken';
+
+		const base64ClientIdAndSecret = Buffer.from(`${oauth2.clientId}:${oauth2.clientSecret}`).toString('base64');
+
 		await mockServerClient("localhost", 1080, null, false).mockAnyResponse({
 			httpRequest: {
 				method: 'POST',
 				path: '/oauth/token',
-				body: 'refresh_token=wrongRefreshToken&client_id=fakeClientId&client_secret=fakeClientSecret&grant_type=refresh_token',
+				headers: {
+					'Authorization': [`Basic ${base64ClientIdAndSecret}`],
+				},
+				body: 'refresh_token=wrongRefreshToken&grant_type=refresh_token',
 			},
 			httpResponse: {
 				statusCode: 400,
@@ -98,21 +117,12 @@ describe('oauth2 accessToken', () => {
 			},
 		});
 
-		const pdClient = lib.ApiClient.instance;
-		const oauth2 = pdClient.authentications.oauth2;
-
-		oauth2.host = 'http://localhost:1080';
-		oauth2.clientId = 'fakeClientId';
-		oauth2.clientSecret = 'fakeClientSecret';
-		oauth2.redirectUri = 'https://example.org';
-		oauth2.refreshToken = 'wrongRefreshToken';
-
 		try {
 			expect(
 				await pdClient.refreshToken()
 			).toThrow();
 		} catch (error) {
-			expect(error.response.text).toBe('{"success":"false","message":"Invalid grant: refresh token is invalid","error":"invalid_grant"}');
+			expect(error.context.error.text).toBe('{"success":"false","message":"Invalid grant: refresh token is invalid","error":"invalid_grant"}');
 		}
 	});
 });

--- a/test/functional/authorisation.test.js
+++ b/test/functional/authorisation.test.js
@@ -4,26 +4,28 @@ const mockServerClient = mockServer.mockServerClient;
 let lib;
 
 describe('oauth2 authorization', () => {
+	let pdClient;
+	let oauth2;
+	let base64ClientIdAndSecret;
+
 	beforeEach(async () => {
 		jest.resetModules();
 
 		lib = require('../../dist');
 
-		await mockServerClient("localhost", 1080, null, false).clear('/oauth/token', 'ALL');
-	});
+		await mockServerClient('localhost', 1080, null, false).clear('/oauth/token', 'ALL');
 
-	it('should authorize and save access and refresh tokens', async () => {
-		const pdClient = lib.ApiClient.instance;
-		const oauth2 = pdClient.authentications.oauth2;
+		pdClient = lib.ApiClient.instance;
+		oauth2 = pdClient.authentications.oauth2;
 
 		oauth2.host = 'http://localhost:1080';
-
 		oauth2.clientId = 'fakeClientId';
 		oauth2.clientSecret = 'fakeClientSecret';
 		oauth2.redirectUri = 'https://example.org';
+		base64ClientIdAndSecret = Buffer.from(`${oauth2.clientId}:${oauth2.clientSecret}`).toString('base64');
+	});
 
-		const base64ClientIdAndSecret = Buffer.from(`${oauth2.clientId}:${oauth2.clientSecret}`).toString('base64');
-
+	it('should authorize and save access and refresh tokens', async () => {
 		await mockServerClient("localhost", 1080, null, false).mockAnyResponse({
 			httpRequest: {
 				method: 'POST',
@@ -66,10 +68,7 @@ describe('oauth2 authorization', () => {
 	});
 
 	it('should throw clientId is not set', async () => {
-		const pdClient = lib.ApiClient.instance;
-		const oauth2 = pdClient.authentications.oauth2;
-
-		oauth2.host = 'http://localhost:1080';
+		oauth2.clientId = null;
 
 		try {
 			expect(
@@ -81,11 +80,7 @@ describe('oauth2 authorization', () => {
 	});
 
 	it('should throw clientSecret is not set', async () => {
-		const pdClient = lib.ApiClient.instance;
-		const oauth2 = pdClient.authentications.oauth2;
-
-		oauth2.host = 'http://localhost:1080';
-		oauth2.clientId = 'fakeClientId';
+		oauth2.clientSecret = null;
 
 		try {
 			expect(
@@ -97,12 +92,7 @@ describe('oauth2 authorization', () => {
 	});
 
 	it('should throw redirectUri is not set', async () => {
-		const pdClient = lib.ApiClient.instance;
-		const oauth2 = pdClient.authentications.oauth2;
-
-		oauth2.host = 'http://localhost:1080';
-		oauth2.clientId = 'fakeClientId';
-		oauth2.clientSecret = 'fakeClientSecret';
+		oauth2.redirectUri = null;
 
 		try {
 			expect(
@@ -114,16 +104,6 @@ describe('oauth2 authorization', () => {
 	});
 
 	it('should throw wrong auth_code', async () => {
-		const pdClient = lib.ApiClient.instance;
-		const oauth2 = pdClient.authentications.oauth2;
-
-		oauth2.host = 'http://localhost:1080';
-		oauth2.clientId = 'fakeClientId';
-		oauth2.clientSecret = 'fakeClientSecret';
-		oauth2.redirectUri = 'https://example.org';
-
-		const base64ClientIdAndSecret = Buffer.from(`${oauth2.clientId}:${oauth2.clientSecret}`).toString('base64');
-
 		await mockServerClient("localhost", 1080, null, false).mockAnyResponse({
 			httpRequest: {
 				method: 'POST',


### PR DESCRIPTION
In scope of this PR existing functional tests are fixed

- tests now expect the new error structure
- Client id and secret are not passed in URL for /oauth/token, so now mockserver requests are correctly matched
- Check correct Authorization header