### PR TITLE
GRAL-2142 add test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "babel src -d dist",
     "prepack": "npm run build",
+    "test": "echo \"Temporarily skipping unit tests\" && exit 0",
     "test:functional": "node ./test/functional/environment.js",
     "test:functional:start": "node ./test/functional/environment.js --start-environment",
     "test:functional:stop": "node ./test/functional/environment.js --stop-environment"


### PR DESCRIPTION
In the scope of this PR `test` script is added in order to support flawless npm package publish flow. As there aren't any unit tests for now, the script just runs echo command similar to here: https://github.com/pipedrive/client-nodejs/blob/master/package.json#L27