### PR TITLE
GRAL-2484 pass jest status code to process.exit

### DIFF
--- a/test/functional/environment.js
+++ b/test/functional/environment.js
@@ -27,7 +27,9 @@ async function runTests() {
 
 	console.log(`./node_modules/.bin/jest ${options.join(' ')}`);
 
-	await shell.exec(`./node_modules/.bin/jest ${options.join(' ')}`);
+	const { code, } = await shell.exec(`./node_modules/.bin/jest ${options.join(' ')}`);
+
+	return code;
 }
 
 async function main() {
@@ -43,9 +45,9 @@ async function main() {
 	}
 
 	try {
-		await runTests();
+		const code = await runTests();
 
-		process.exit(0);
+		process.exit(code || 0);
 	} catch (error) {
 		console.log(error);
 		process.exit(1);


### PR DESCRIPTION
If functional tests fail, the jest process status code is not passed to the output of `npm run test:functional` which means that there isn't a good way to identify if tests passed or not.  This change will make sure that correct exit code is passed.