### PR TITLE
GRAL-2482 use dist folder for automation functional tests

### DIFF
--- a/test/functional/access-token.test.js
+++ b/test/functional/access-token.test.js
@@ -1,4 +1,5 @@
 const mockServer = require('mockserver-client');
+const { getSrc } = require('./utils');
 const mockServerClient = mockServer.mockServerClient;
 
 let lib;
@@ -12,7 +13,7 @@ describe('oauth2 accessToken', () => {
 	beforeEach(async () => {
 		jest.resetModules();
 
-		lib = require('../../src');
+		lib = getSrc();
 
 		await mockServerClient('localhost', global.MOCK_PORT, null, false).clear('/oauth/token', 'ALL');
 
@@ -29,7 +30,7 @@ describe('oauth2 accessToken', () => {
 	it('should refresh accessToken with valid refreshToken', async () => {
 		oauth2.refreshToken = 'fakeRefreshToken';
 
-		await mockServerClient("localhost", global.MOCK_PORT, null, false).mockAnyResponse({
+		await mockServerClient('localhost', global.MOCK_PORT, null, false).mockAnyResponse({
 			httpRequest: {
 				method: 'POST',
 				path: '/oauth/token',
@@ -41,7 +42,7 @@ describe('oauth2 accessToken', () => {
 			httpResponse: {
 				statusCode: 200,
 				headers: {
-					"content-type": ['application/json; charset=utf-8'],
+					'content-type': ['application/json; charset=utf-8'],
 				},
 				body: JSON.stringify({
 					access_token: 'freshAccessToken',
@@ -83,7 +84,7 @@ describe('oauth2 accessToken', () => {
 	it('should throw wrong refresh token', async () => {
 		oauth2.refreshToken = 'wrongRefreshToken';
 
-		await mockServerClient("localhost", global.MOCK_PORT, null, false).mockAnyResponse({
+		await mockServerClient('localhost', global.MOCK_PORT, null, false).mockAnyResponse({
 			httpRequest: {
 				method: 'POST',
 				path: '/oauth/token',
@@ -95,7 +96,7 @@ describe('oauth2 accessToken', () => {
 			httpResponse: {
 				statusCode: 400,
 				headers: {
-					"content-type": ['application/json; charset=utf-8'],
+					'content-type': ['application/json; charset=utf-8'],
 				},
 				body: JSON.stringify({
 					success: 'false',

--- a/test/functional/authorisation.test.js
+++ b/test/functional/authorisation.test.js
@@ -1,4 +1,7 @@
 const mockServer = require('mockserver-client');
+
+const { getSrc } = require('./utils');
+
 const mockServerClient = mockServer.mockServerClient;
 
 let lib;
@@ -11,7 +14,7 @@ describe('oauth2 authorization', () => {
 	beforeEach(async () => {
 		jest.resetModules();
 
-		lib = require('../../src');
+		lib = getSrc();
 
 		await mockServerClient('localhost', global.MOCK_PORT, null, false).clear('/oauth/token', 'ALL');
 
@@ -26,7 +29,7 @@ describe('oauth2 authorization', () => {
 	});
 
 	it('should authorize and save access and refresh tokens', async () => {
-		await mockServerClient("localhost", global.MOCK_PORT, null, false).mockAnyResponse({
+		await mockServerClient('localhost', global.MOCK_PORT, null, false).mockAnyResponse({
 			httpRequest: {
 				method: 'POST',
 				path: '/oauth/token',
@@ -38,7 +41,7 @@ describe('oauth2 authorization', () => {
 			httpResponse: {
 				statusCode: 200,
 				headers: {
-					"content-type": ['application/json; charset=utf-8'],
+					'content-type': ['application/json; charset=utf-8'],
 				},
 				body: JSON.stringify({
 					access_token: 'freshAccessToken',
@@ -104,7 +107,7 @@ describe('oauth2 authorization', () => {
 	});
 
 	it('should throw wrong auth_code', async () => {
-		await mockServerClient("localhost", global.MOCK_PORT, null, false).mockAnyResponse({
+		await mockServerClient('localhost', global.MOCK_PORT, null, false).mockAnyResponse({
 			httpRequest: {
 				method: 'POST',
 				path: '/oauth/token',
@@ -116,7 +119,7 @@ describe('oauth2 authorization', () => {
 			httpResponse: {
 				statusCode: 400,
 				headers: {
-					"content-type": ['application/json; charset=utf-8'],
+					'content-type': ['application/json; charset=utf-8'],
 				},
 				body: JSON.stringify({
 					success: 'false',

--- a/test/functional/automatic-token-refresh.test.js
+++ b/test/functional/automatic-token-refresh.test.js
@@ -1,5 +1,6 @@
 const mockServer = require('mockserver-client');
-const {BaseUser} = require("../../src");
+
+const { getSrc } = require('./utils');
 
 const mockServerClient = mockServer.mockServerClient;
 
@@ -90,7 +91,7 @@ describe('automatic token refresh in api calls', () => {
 	beforeEach(async () => {
 		jest.resetModules();
 
-		lib = require('../../src');
+		lib = getSrc();
 
 		await mockServerClient('localhost', global.MOCK_PORT, null, false).clear('/oauth/token', 'ALL');
 		await mockServerClient('localhost', global.MOCK_PORT, null, false).clear('/v1/users', 'ALL');
@@ -117,7 +118,7 @@ describe('automatic token refresh in api calls', () => {
 					},
 				],
 			});
-		}catch(err) {
+		} catch(err) {
 			console.log('Logging error!');
 			console.log(err.message);
 			console.log(JSON.stringify(err));
@@ -132,7 +133,7 @@ describe('automatic token refresh in api calls', () => {
 
 		const users = await new lib.UsersApi().getUsers();
 
-		const expectedUser = BaseUser.constructFromObject({ id: 1 ,name: 'John Doe' });
+		const expectedUser = lib.BaseUser.constructFromObject({ id: 1 ,name: 'John Doe' });
 
 		expect(users).toEqual({
 			success: true,

--- a/test/functional/environment.js
+++ b/test/functional/environment.js
@@ -10,7 +10,7 @@ function startEnvironment(serverPort) {
 	return mockServer.start_mockserver({
 		serverPort,
 		trace: true,
-		verbose: true,
+		verbose: false,
 	});
 }
 
@@ -88,7 +88,6 @@ class JestEnvironment extends JestNodeEnvironment {
 		this.global.MOCK_SERVER = `http://localhost:${port}`;
 	}
 }
-
 
 if (require.main === module) {
 	main();

--- a/test/functional/utils.js
+++ b/test/functional/utils.js
@@ -1,0 +1,7 @@
+export function getSrc() {
+	if (process.env.AUTOMATION) {
+		return require('../../dist');
+	}
+
+	return require('../../src');
+}

--- a/test/functional/utils.js
+++ b/test/functional/utils.js
@@ -1,7 +1,1 @@
-export function getSrc() {
-	if (process.env.AUTOMATION) {
-		return require('../../dist');
-	}
-
-	return require('../../src');
-}
+export const getSrc = () => process.env.AUTOMATION ? require('../../dist') : require('../../src');


### PR DESCRIPTION
Functional tests currently use src files to run tests on. During automation we want to test generated SDKs which is in dist folder. This change looks for AUTOMATION env variable and uses dist folder instead as testable files.