### PR TITLE
Move babel runtime back to deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The file format of it is based on [Keep a Changelog](http://keepachangelog.com/e
 For public Changelog covering all changes done to Pipedrive’s API, webhooks and app extensions platforms, see [public Changelog](https://pipedrive.readme.io/docs/changelog) with discussion area in [Developers Community](https://devcommunity.pipedrive.com/c/documentation/changelog/19).
 
 ## [Unreleased]
+### Fixed
 - Move @babel/runtime from devDependencies to dependencies to fix a runtime error
 
 ## 18.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ The file format of it is based on [Keep a Changelog](http://keepachangelog.com/e
 For public Changelog covering all changes done to Pipedrive’s API, webhooks and app extensions platforms, see [public Changelog](https://pipedrive.readme.io/docs/changelog) with discussion area in [Developers Community](https://devcommunity.pipedrive.com/c/documentation/changelog/19).
 
 ## [Unreleased]
+
+## 18.0.0
 ### Security
 - Removed `.instance` static property from sdk client to prevent race conditions when using it as a singleton
 See the updated examples in the readme to get an overview of the necessary code changes.
+
 ## 17.5.2
 ### Changed
 - Updated endpoint descriptions to warn about permanently removing deleted entities:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The file format of it is based on [Keep a Changelog](http://keepachangelog.com/e
 For public Changelog covering all changes done to Pipedrive’s API, webhooks and app extensions platforms, see [public Changelog](https://pipedrive.readme.io/docs/changelog) with discussion area in [Developers Community](https://devcommunity.pipedrive.com/c/documentation/changelog/19).
 
 ## [Unreleased]
+- Move @babel/runtime from devDependencies to dependencies to fix a runtime error
 
 ## 18.0.0
 ### Security

--- a/package-lock.json
+++ b/package-lock.json
@@ -1277,7 +1277,6 @@
       "version": "7.20.1",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.1.tgz",
       "integrity": "sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.10"
       }
@@ -8460,8 +8459,7 @@
     "regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "dev": true
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "regenerator-transform": {
       "version": "0.15.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   },
   "dependencies": {
     "lodash": "^4.17.21",
-    "superagent": "^7.1.3"
+    "superagent": "^7.1.3",
+    "@babel/runtime": "^7.20.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",
@@ -46,7 +47,6 @@
     "@babel/plugin-transform-runtime": "^7.12.1",
     "@babel/preset-env": "^7.0.0",
     "@babel/register": "^7.0.0",
-    "@babel/runtime": "^7.20.1",
     "babel-eslint": "^10.1.0",
     "changelog-updater": "^2.0.3",
     "eslint": "^8.27.0",


### PR DESCRIPTION
### Moved
- Moving the babel runtime dependency back to dependencies as 
### Added
- Added the missing paragraph header to 18.0.0 changelog message