### PR TITLE
Fix cookiejar Regular Expression Denial of Service via Cookie.parse function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3368,9 +3368,9 @@
       "dev": true
     },
     "cookiejar": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
-      "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ=="
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw=="
     },
     "copy-descriptor": {
       "version": "0.1.1",


### PR DESCRIPTION
## Changes : 
Effected of the project `pipedrive/client-nodejs` used cookiejar before 2.1.4 are vulnerable to Regular Expression Denial of Service (ReDoS) via the `Cookie.parse` function and other aspects of the API, which use an insecure regular expression for parsing cookie values. Applications could be stalled for extended periods of time if untrusted input is passed to cookie values or attempted to parse from request headers.

**Proof of concept:**
```js
ts\nconst { CookieJar } = require("cookiejar");

const jar = new CookieJar();

const start = performance.now();

const attack = "a" + "t".repeat(50_000);
jar.setCookie(attack);

console.log(`CookieJar.setCookie(): ${performance.now() - start}ms`);
```
```
CookieJar.setCookie(): 2963.214399999939ms
```

## Operational Impact
CVE-2022-25901
[CWE-1333](https://cwe.mitre.org/data/definitions/1333.html)
`CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L`