### PR TITLE
refactor: enhance Axios type definitions in BaseAPI and OAuth2Configu…

### DIFF
--- a/src/versions/v1/base.ts
+++ b/src/versions/v1/base.ts
@@ -16,7 +16,7 @@
 import type { Configuration } from './configuration';
 // Some imports not used depending on template conditions
 // @ts-ignore
-import type { AxiosError, AxiosResponse, AxiosRequestConfig , InternalAxiosRequestConfig } from 'axios';
+import type { AxiosError, AxiosResponse, AxiosRequestConfig , InternalAxiosRequestConfig, AxiosInstance } from 'axios';
 import axios from 'axios';
 import { join, dirname } from 'path';
 import { existsSync } from 'fs';
@@ -95,7 +95,7 @@ export const errorInterceptor = (error: AxiosError) => {
 export class BaseAPI {
     protected configuration: Configuration | undefined;
     protected basePath: string = BASE_PATH;
-    protected axios = axios.create();
+    protected axios: AxiosInstance = axios.create();
     constructor(configuration: Configuration) {
         if (configuration) {
             this.configuration = configuration;

--- a/src/versions/v1/configuration.ts
+++ b/src/versions/v1/configuration.ts
@@ -13,7 +13,7 @@
  */
 
 
-import axios from "axios";
+import axios, { AxiosResponse } from "axios";
 import { stringify } from "qs";
 import { errorInterceptor, responseInterceptor, versionInterceptor } from './base';
 
@@ -186,7 +186,7 @@ export class OAuth2Configuration {
     * Revoke Refresh Token aka marking an app uninstalled or revoke the Access Token.
     * @param {String} tokenTypeHint values can be: 'access_token' or 'refresh_token'.
 */
-  public async revokeToken(tokenTypeHint?: 'access_token' | 'refresh_token') {
+  public async revokeToken(tokenTypeHint?: 'access_token' | 'refresh_token'): Promise<AxiosResponse<any, any>> {
 
     const token = tokenTypeHint === 'refresh_token'
         ? this.refreshToken : encodeURIComponent(this.accessToken);


### PR DESCRIPTION
This changes will resolve some issues I've been facing with the axios dependency.
Node version: v20.12.2
TS version: 5.7.3
My project has this axios package and types versions
```
 "@types/axios": "^0.14.4",
 "axios": "^1.7.9",
```
this is the error im getting when I build the project.
![image](https://github.com/user-attachments/assets/8203a182-a203-4a0c-88ee-625578f94628)

When the code is fixed with the types like in this PR the issue is fixed.
