### PR TITLE
GRAL-5119 Bump axios, update README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The file format of it is based on [Keep a Changelog](http://keepachangelog.com/e
 For public Changelog covering all changes done to Pipedrive’s API, webhooks and app extensions platforms, see [public Changelog](https://pipedrive.readme.io/docs/changelog) with discussion area in [Developers Community](https://devcommunity.pipedrive.com/c/documentation/changelog/19).
 
 ## [Unreleased]
+### Changed
+- Bump `axios` from `1.3.3` to `1.9.0`
+- Update README with an example of fetching deal details
 
 ## [27.1.1] - 2025-05-23
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -49,10 +49,12 @@ app.listen(PORT, () => {
 
 app.get("/", async (req, res) => {
   const dealsApi = new DealsApi(apiConfig);
-  const response = await dealsApi.getDeals();
-  const { data: deals } = response;
+  const responseAllDeals = await dealsApi.getDeals();
+  const { data: deals } = responseAllDeals;
+  const responseOneDeal = await dealsApi.getDeal({ id: 1 });
+  const { data: deal } = responseOneDeal;
 
-  res.send(deals);
+  res.send({ deals, deal });
 });
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "27.1.1",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.3.3",
+        "axios": "^1.9.0",
         "qs": "^6.11.0"
       },
       "devDependencies": {
@@ -3548,9 +3548,10 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "fs": false
   },
   "dependencies": {
-    "axios": "^1.3.3",
+    "axios": "^1.9.0",
     "qs": "^6.11.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Related Tickets & Documents

Tackling those two issues:
https://github.com/pipedrive/client-nodejs/issues/615
https://github.com/pipedrive/client-nodejs/issues/620

## Description

* Bump `axios` to latest version `1.9.0`
* Add an example to the README about how to fetch one deal details
