### PR TITLE
feat(api): add optional mail message body field and include_body param

### DIFF
--- a/src/versions/v1/api/deals-api.ts
+++ b/src/versions/v1/api/deals-api.ts
@@ -3197,6 +3197,13 @@ export interface DealsApiGetDealMailMessagesRequest {
      * @memberof DealsApiGetDealMailMessages
      */
     readonly limit?: number
+
+    /**
+     * Whether to include the mail message body content in response. 0 &#x3D; No, 1 &#x3D; Yes. If omitted, defaults to 0.
+     * @type {0 | 1}
+     * @memberof DealsApiGetDealMailMessages
+     */
+    readonly include_body?: 0 | 1
 }
 
 /**

--- a/src/versions/v1/api/persons-api.ts
+++ b/src/versions/v1/api/persons-api.ts
@@ -677,10 +677,11 @@ export const PersonsApiAxiosParamCreator = function (configuration?: Configurati
          * @param {number} id The ID of the person
          * @param {number} [start] Pagination start
          * @param {number} [limit] Items shown per page
+         * @param {0 | 1} [include_body] Whether to include the mail message body content in response. Yes. If omitted, defaults to 0.
 
          * @throws {RequiredError}
          */
-        getPersonMailMessages: async (id: number, start?: number, limit?: number, ): Promise<RequestArgs> => {
+        getPersonMailMessages: async (id: number, start?: number, limit?: number, include_body?: 0 | 1): Promise<RequestArgs> => {
             // verify required parameter 'id' is not null or undefined
             assertParamExists('getPersonMailMessages', 'id', id)
             const localVarPath = `/persons/{id}/mailMessages`
@@ -711,7 +712,9 @@ export const PersonsApiAxiosParamCreator = function (configuration?: Configurati
                 localVarQueryParameter['limit'] = limit;
             }
 
-
+            if (include_body !== undefined) {
+                localVarQueryParameter['include_body'] = include_body;
+            }
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -2018,6 +2021,13 @@ export interface PersonsApiGetPersonMailMessagesRequest {
      * @memberof PersonsApiGetPersonMailMessages
      */
     readonly limit?: number
+
+    /**
+     * Whether to include the mail message body content in response. 0 &#x3D; No, 1 &#x3D; Yes. If omitted, defaults to 0.
+     * @type {0 | 1}
+     * @memberof PersonsApiGetPersonMailMessages
+     */
+    readonly include_body?: 0 | 1
 }
 
 /**

--- a/src/versions/v1/models/mail-message-data.ts
+++ b/src/versions/v1/models/mail-message-data.ts
@@ -54,6 +54,11 @@ export interface MailMessageData {
     */
     'body_url'?: string;
     /**
+    * The mail message body content
+    * @type {string}
+    */
+    'body'?: string;
+    /**
     * The connection account ID
     * @type {string}
     */


### PR DESCRIPTION
Add 'body' field to MailMessageData interface to support returning mail message content. Add optional 'include_body' query parameter to getDealMailMessages and getPersonMailMessages endpoints to control inclusion of body content in response.

## Related Tickets & Documents

<!--
Add task/issue you were working on and any other documents.
-->

## Description

Pipedrive API for getting mails associated to a person (`GET /v1/persons/{id}/mailMessages`)  or a deal (`GET /v1/deals/{id}/mailMessages`) can include the query param `incude_body` to pull the content of the mails. While this is supported by the API, it is not available in this nodejs client.

## Type of PR?

<!-- Remove the comment blocks to uncomment all applicable types -->

<!-- - 🍕 New feature -->
🐛 Bug Fix
🚀 Enhancement
<!-- - 🚧 Maintenance -->
<!-- - 🏗️ Other: [Specify your type] -->

## Manual testing

<!--  Outline manual tests performed to verify the changes.
Attach any Screenshots 📸
-->

## Automated tests added?

<!-- Add an 'X' in the box to check them. ex: [x]  -->

- [ ] 👍 Unit tests
- [ ] 👍 Functional tests
- [ ] 👍 E2E tests
- [ ] 🙅 N/A
