### PR TITLE
Switch to OIDC Trusted Publishers for npm publish

### DIFF
--- a/.github/workflows/cicd_npm-publish.yml
+++ b/.github/workflows/cicd_npm-publish.yml
@@ -9,6 +9,10 @@ jobs:
   publish:
     if: ${{ github.event.label.name == 'npm-ready-for-publish' }}
     uses: pipedrive-actions/github-actions-workflows/.github/workflows/reusable_cicd-npm-publish.yml@master
+    permissions:
+      id-token: write
+      contents: write
     with:
       revision: ${{ github.event.pull_request.head.ref }}
+      use_trusted_publisher: true
     secrets: inherit


### PR DESCRIPTION
Switch npm publishing from token-based auth to OIDC Trusted Publishers.

- Add `use_trusted_publisher: true` to reusable workflow call
- Add `permissions` block (`id-token: write`, `contents: write`) for OIDC token issuance
- No `NPM_PUBLIC_PUBLISH_TOKEN` secret needed after npmjs.org Trusted Publisher is configured

**Manual steps still required before E2E:**
1. Verify `client-nodejs` is in Pipedrive Public GHA Bot's repo access list
2. Verify `PD_PUBLIC_GHA_BOT_CLIENT_ID` variable is available
3. Add Trusted Publisher on npmjs.com for `pipedrive` package (org: `pipedrive`, repo: `client-nodejs`, workflow: `cicd_npm-publish.yml`)