### PR TITLE
CICDL-378: Remove unused use_trusted_publisher input

### DIFF
--- a/.github/workflows/cicd_npm-publish.yml
+++ b/.github/workflows/cicd_npm-publish.yml
@@ -14,5 +14,4 @@ jobs:
       contents: write
     with:
       revision: ${{ github.event.pull_request.head.ref }}
-      use_trusted_publisher: true
     secrets: inherit


### PR DESCRIPTION
## Summary

- Removes the now-unnecessary `use_trusted_publisher: true` input from the npm publish workflow call

OIDC Trusted Publishers is the only publish path after [pipedrive-actions/github-actions-workflows#4](https://github.com/pipedrive-actions/github-actions-workflows/pull/4) removed the token-based code path.

**⚠️ Merge after** [pipedrive-actions/github-actions-workflows#4](https://github.com/pipedrive-actions/github-actions-workflows/pull/4) is merged.

## Test plan

- [ ] No functional change — OIDC publish continues to work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)