### PR TITLE
GRAL-6005 replace pull_request_target with pull_request

### DIFF
--- a/.github/workflows/on-commit.yml
+++ b/.github/workflows/on-commit.yml
@@ -1,6 +1,6 @@
 name: On Commit
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - master
 

--- a/.github/workflows/on-pd-bot-pr-opened.yml
+++ b/.github/workflows/on-pd-bot-pr-opened.yml
@@ -1,7 +1,7 @@
 name: On Pipedrive Bot PR opened
 
 on:
-  pull_request_target:
+  pull_request:
     types: [labeled]
     branches:
       - master


### PR DESCRIPTION
Jira: https://pipedrive.atlassian.net/browse/GRAL-6005

## Summary

Replaces the `pull_request_target` trigger with `pull_request` in two GitHub Actions workflows, per a suggestion raised in `#devops-public`.

- **`on-commit.yml`**: was using `pull_request_target` with no `ref` override on checkout, so it always tested `master` instead of the PR's actual changes. It doesn't use any secrets, so there's no reason for the elevated trigger. Switching to `pull_request` fixes both issues — it removes unneeded secret/write-token exposure and makes checkout default to the PR's merge commit.
- **`on-pd-bot-pr-opened.yml`**: was using `pull_request_target`, gated on `github.actor == 'pipedrive-bot'` (same-repo bot PRs only). `pull_request` works identically for this case and removes the theoretical risk of fork PRs executing code if the actor check is ever bypassed.
